### PR TITLE
feat: Phase 3 — Formula-based contract system with 3-contract market

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,8 @@ Key project files
 - `src/config_loader.rs` — JSON config embedding and loading
 - `src/game_state.rs` — `GameState` struct, game mechanics (card/token/contract operations), action dispatch
 - `src/action_log.rs` — `PlayerAction` enum, `ActionEntry`, `ActionLog` for deterministic replay
-- `src/endpoints.rs` — HTTP handlers: `POST /action`, `GET /state`, `GET /actions/history`
+- `src/contract_generation.rs` — formula-based contract and reward card generation (TierScalingFormula)
+- `src/endpoints.rs` — HTTP handlers: `POST /action`, `GET /state`, `GET /actions/history`, `GET /contracts/available`
 - `src/starter_cards.rs` — starter deck card definitions (3 pure production types)
 - `configurations/general/game_rules.json` — externalized game constants
 - `Makefile` — `check`, `coverage`, `install-hooks` targets
@@ -76,6 +77,7 @@ Key project files
 - `.github/workflows/ci.yml` — GitHub Actions CI pipeline
 - `tests/smoke_test.rs` — smoke tests for server endpoints
 - `tests/types_serialization_test.rs` — serialization roundtrip tests for core types
+- `tests/contract_system_test.rs` — integration tests for contract generation, market mechanics, and reward cards
 - `tests/game_loop_test.rs` — integration tests for the basic game loop (full cycle, errors, persistence)
 - `tests/determinism_test.rs` — deterministic replay and seed reproducibility tests
 

--- a/configurations/general/game_rules.json
+++ b/configurations/general/game_rules.json
@@ -5,5 +5,21 @@
         "contracts_per_tier_to_advance": 10,
         "contract_market_size_per_tier": 3,
         "discard_production_unit_bonus": 1
+    },
+    "contract_formulas": {
+        "output_threshold": {
+            "min_tier": 1,
+            "base_min": 4,
+            "base_max": 10,
+            "per_tier_min": 1,
+            "per_tier_max": 5
+        },
+        "reward_production": {
+            "min_tier": 1,
+            "base_min": 0,
+            "base_max": 1,
+            "per_tier_min": 1,
+            "per_tier_max": 2
+        }
     }
 }

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -114,27 +114,29 @@ The existing [my_little_card_game](https://github.com/RobbingDaHood/my_little_ca
 
 ---
 
-## Phase 3: Contract System
+## Phase 3: Contract System ✅
 
-**Goal**: Tier 1 contracts with simple requirements. Fail/succeed flow with new contracts offered on completion or failure. This simple setup will be overwritten/exanded in pahse 6: Try not to develop something that contradicts that phase. 
+**Goal**: Tier 1 contracts with simple requirements. Formula-based generation with a 3-contract market per unlocked tier. Infrastructure supports arbitrary tiers for Phase 6.
 
 **Deliverables**:
-- Contract generation with formula-based requirement values:
+- `src/contract_generation.rs` — formula-based contract and reward card generation using `TierScalingFormula`:
     - Each contract has a list of enum-based requirements
-    - Tier 1 contracts: 1–2 requirements, at least one output threshold
+    - Tier 1 contracts: 1 requirement (OutputThreshold for ProductionUnit, range [5,15])
     - Concrete requirement values generated from tier-based formulas with deterministic randomization
+    - `min_tier` field on each formula gates when requirement/effect types become available
 - Contract reward cards generated at contract creation time:
     - Reward card has same number of card effects as contract has requirements
     - Each effect matches the tier of a corresponding requirement
+    - Tier 1: PureProduction effect producing [1,3] ProductionUnit (matches starter deck range)
     - Concrete effect values rolled from tier formulas — visible to player before accepting
-    - Likely there is just one tier 1 card effect of production: With some range (that matches the cards already in the players hand at start of the game)
-        - Do not roll the initial player hand from this card effect, because we want a static known somewhat balanced start of the game. 
-- Contract market: player chooses from 2-3 available contracts pr. unlocked tier
+- Contract market: 3 available contracts per unlocked tier, refills (not regenerates) after completion
 - Contract completion: auto-completes when all requirements are met, awards the reward card
-- Contract failure: no penalty beyond lost time; new contract offered
+- No abandon action: contracts either auto-complete or auto-fail (auto-fail only relevant for future tiers with HarmfulTokenLimit/TurnWindow, added in Phase 6)
 - `GET /contracts/available` — list available contracts (including reward card preview)
 - `POST /action` — accept a contract
-- Integration tests for contract success and failure paths
+- `src/config.rs` — `ContractFormulasConfig` and `TierScalingFormula` structs
+- `configurations/general/game_rules.json` — `contract_formulas` section with formula parameters
+- `tests/contract_system_test.rs` — 11 integration tests covering market structure, validation, refill, determinism, and rewards
 
 **Reference files from card game**:
 - `src/library/disciplines/` — encounter logic patterns (adapt to contract evaluation)

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use rocket::serde::Deserialize;
 #[serde(crate = "rocket::serde")]
 pub struct GameRulesConfig {
     pub general: GeneralRules,
+    pub contract_formulas: ContractFormulasConfig,
 }
 
 /// General (non-tier-specific) game constants.
@@ -26,4 +27,25 @@ pub struct GeneralRules {
     pub contract_market_size_per_tier: u32,
     /// Production units gained when discarding a card for baseline benefit.
     pub discard_production_unit_bonus: u32,
+}
+
+/// Formula parameters for contract and reward card generation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(crate = "rocket::serde")]
+pub struct ContractFormulasConfig {
+    pub output_threshold: TierScalingFormula,
+    pub reward_production: TierScalingFormula,
+}
+
+/// A linear tier-scaling formula: for a given tier, produces a range
+/// `[base_min + tier × per_tier_min, base_max + tier × per_tier_max]`.
+/// Only active for tiers ≥ `min_tier`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(crate = "rocket::serde")]
+pub struct TierScalingFormula {
+    pub min_tier: u32,
+    pub base_min: u32,
+    pub base_max: u32,
+    pub per_tier_min: u32,
+    pub per_tier_max: u32,
 }

--- a/src/contract_generation.rs
+++ b/src/contract_generation.rs
@@ -1,0 +1,116 @@
+//! Formula-based contract and reward card generation.
+//!
+//! Contracts are generated per tier using `TierScalingFormula` parameters.
+//! Each formula produces a range `[base_min + tier × per_tier_min,
+//! base_max + tier × per_tier_max]` and a value is rolled uniformly
+//! within that range using the seeded RNG.
+
+use rand::RngCore;
+use rand_pcg::Pcg64;
+
+use crate::config::{ContractFormulasConfig, TierScalingFormula};
+use crate::types::{
+    CardEffect, CardTag, Contract, ContractRequirementKind, ContractTier, PlayerActionCard,
+    TokenAmount, TokenType,
+};
+
+type RequirementGenerator = Box<dyn Fn(&mut Pcg64) -> ContractRequirementKind>;
+
+/// Roll a value from a tier-scaling formula for the given tier.
+fn roll_from_formula(tier: u32, formula: &TierScalingFormula, rng: &mut Pcg64) -> u32 {
+    let min = formula.base_min + tier * formula.per_tier_min;
+    let max = formula.base_max + tier * formula.per_tier_max;
+    if min >= max {
+        return min;
+    }
+    let range = max - min + 1;
+    min + (rng.next_u32() % range)
+}
+
+/// Returns the requirement types available at the given tier, paired with
+/// a generator function. Currently only OutputThreshold is implemented;
+/// Phase 6 will add more types gated by `min_tier`.
+fn available_requirement_generators(
+    tier: u32,
+    formulas: &ContractFormulasConfig,
+) -> Vec<RequirementGenerator> {
+    let mut generators: Vec<RequirementGenerator> = Vec::new();
+
+    if tier >= formulas.output_threshold.min_tier {
+        let formula = formulas.output_threshold.clone();
+        generators.push(Box::new(move |rng: &mut Pcg64| {
+            ContractRequirementKind::OutputThreshold {
+                token_type: TokenType::ProductionUnit,
+                min_amount: roll_from_formula(tier, &formula, rng),
+            }
+        }));
+    }
+
+    generators
+}
+
+/// Determine the number of requirements for a contract at the given tier.
+/// Vision rule: tier X → max(X−1, 1) to X+1 requirements, capped by
+/// the number of available requirement types.
+fn roll_requirement_count(tier: u32, available_types: usize, rng: &mut Pcg64) -> usize {
+    let min_reqs = (tier.saturating_sub(1)).max(1) as usize;
+    let max_reqs = (tier + 1) as usize;
+    let max_reqs = max_reqs.min(available_types);
+    let min_reqs = min_reqs.min(max_reqs);
+    if min_reqs == max_reqs {
+        return min_reqs;
+    }
+    let range = max_reqs - min_reqs + 1;
+    min_reqs + (rng.next_u32() as usize % range)
+}
+
+/// Generate a single contract for the given tier.
+pub fn generate_contract(
+    tier: ContractTier,
+    rng: &mut Pcg64,
+    formulas: &ContractFormulasConfig,
+) -> Contract {
+    let generators = available_requirement_generators(tier.0, formulas);
+    let req_count = roll_requirement_count(tier.0, generators.len(), rng);
+
+    let mut requirements = Vec::with_capacity(req_count);
+    for i in 0..req_count {
+        let gen_idx = i % generators.len();
+        requirements.push(generators[gen_idx](rng));
+    }
+
+    let reward_card = generate_reward_card(tier, requirements.len(), rng, formulas);
+
+    Contract {
+        tier,
+        requirements,
+        reward_card,
+    }
+}
+
+/// Generate a reward card with the given number of effects at the given tier.
+fn generate_reward_card(
+    tier: ContractTier,
+    num_effects: usize,
+    rng: &mut Pcg64,
+    formulas: &ContractFormulasConfig,
+) -> PlayerActionCard {
+    let effects: Vec<CardEffect> = (0..num_effects)
+        .map(|_| {
+            let amount = roll_from_formula(tier.0, &formulas.reward_production, rng);
+            CardEffect::new(
+                vec![],
+                vec![TokenAmount {
+                    token_type: TokenType::ProductionUnit,
+                    amount,
+                }],
+            )
+            .expect("reward card effect with production output is always valid")
+        })
+        .collect();
+
+    PlayerActionCard {
+        tags: vec![CardTag::Production],
+        effects,
+    }
+}

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -10,6 +10,7 @@ use std::sync::Mutex;
 
 use crate::action_log::{ActionEntry, PlayerAction};
 use crate::game_state::{ActionResult, GameState, GameStateView};
+use crate::types::TierContracts;
 
 /// Dispatch a player action.
 ///
@@ -49,4 +50,16 @@ pub fn get_state(game_state: &State<Mutex<GameState>>) -> Json<GameStateView> {
 pub fn get_actions_history(game_state: &State<Mutex<GameState>>) -> Json<Vec<ActionEntry>> {
     let gs = game_state.lock().expect("game state lock poisoned");
     Json(gs.action_log().entries().to_vec())
+}
+
+/// Available contracts in the market.
+///
+/// Returns the currently offered contracts grouped by tier, including
+/// each contract's requirements and reward card preview. The player can
+/// inspect these before accepting one via `POST /action`.
+#[openapi]
+#[get("/contracts/available")]
+pub fn get_contracts_available(game_state: &State<Mutex<GameState>>) -> Json<Vec<TierContracts>> {
+    let gs = game_state.lock().expect("game state lock poisoned");
+    Json(gs.offered_contracts().to_vec())
 }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -12,9 +12,10 @@ use rand_pcg::Pcg64;
 use crate::action_log::{ActionLog, PlayerAction};
 use crate::config::GameRulesConfig;
 use crate::config_loader::load_game_rules;
+use crate::contract_generation::generate_contract;
 use crate::starter_cards::create_starter_deck;
 use crate::types::{
-    CardCounts, CardEffect, CardEntry, CardTag, Contract, ContractRequirementKind, ContractTier,
+    CardCounts, CardEffect, CardEntry, Contract, ContractRequirementKind, ContractTier,
     PlayerActionCard, TierContracts, TokenAmount, TokenType,
 };
 
@@ -163,7 +164,7 @@ impl GameState {
         };
 
         // Generate first offered contracts
-        state.generate_offered_contracts();
+        state.refill_contract_market();
 
         state
     }
@@ -195,6 +196,10 @@ impl GameState {
 
     pub fn action_log(&self) -> &ActionLog {
         &self.action_log
+    }
+
+    pub fn offered_contracts(&self) -> &[TierContracts] {
+        &self.offered_contracts
     }
 
     pub fn seed(&self) -> u64 {
@@ -367,38 +372,58 @@ impl GameState {
     // Contract mechanics
     // -------------------------------------------------------------------
 
-    fn generate_offered_contracts(&mut self) {
-        // Placeholder — Phase 3 will replace this with formula-based generation.
-        let min_amount = 5u32;
-        let max_amount = 15u32;
-        let range = max_amount - min_amount + 1;
-        let rolled = min_amount + (self.rng.next_u32() % range);
+    fn refill_contract_market(&mut self) {
+        let target = self.rules.general.contract_market_size_per_tier;
 
-        let reward_card = PlayerActionCard {
-            tags: vec![CardTag::Production],
-            effects: vec![CardEffect::new(
-                vec![],
-                vec![TokenAmount {
-                    token_type: TokenType::ProductionUnit,
-                    amount: 2,
-                }],
-            )
-            .expect("reward card effect is always valid")],
-        };
+        for tier_num in self.unlocked_tiers() {
+            let tier = ContractTier(tier_num);
 
-        let contract = Contract {
-            tier: ContractTier(1),
-            requirements: vec![ContractRequirementKind::OutputThreshold {
-                token_type: TokenType::ProductionUnit,
-                min_amount: rolled,
-            }],
-            reward_card,
-        };
+            let existing_count = self
+                .offered_contracts
+                .iter()
+                .find(|tc| tc.tier == tier)
+                .map(|tc| tc.contracts.len() as u32)
+                .unwrap_or(0);
 
-        self.offered_contracts = vec![TierContracts {
-            tier: ContractTier(1),
-            contracts: vec![contract],
-        }];
+            let needed = target.saturating_sub(existing_count);
+            if needed == 0 {
+                continue;
+            }
+
+            let new_contracts: Vec<Contract> = (0..needed)
+                .map(|_| generate_contract(tier, &mut self.rng, &self.rules.contract_formulas))
+                .collect();
+
+            if let Some(tc) = self.offered_contracts.iter_mut().find(|tc| tc.tier == tier) {
+                tc.contracts.extend(new_contracts);
+            } else {
+                self.offered_contracts.push(TierContracts {
+                    tier,
+                    contracts: new_contracts,
+                });
+            }
+        }
+    }
+
+    /// Returns the list of unlocked tier numbers.
+    /// Tier 1 is always unlocked. Tier N+1 unlocks when
+    /// `ContractsTierCompleted(N) >= contracts_per_tier_to_advance`.
+    fn unlocked_tiers(&self) -> Vec<u32> {
+        let threshold = self.rules.general.contracts_per_tier_to_advance;
+        let mut tiers = vec![1u32];
+        for tier in 1.. {
+            let completed = self
+                .tokens
+                .get(&TokenType::ContractsTierCompleted(tier))
+                .copied()
+                .unwrap_or(0);
+            if completed >= threshold {
+                tiers.push(tier + 1);
+            } else {
+                break;
+            }
+        }
+        tiers
     }
 
     fn try_complete_contract(&mut self) -> Option<Contract> {
@@ -415,7 +440,7 @@ impl GameState {
         self.add_reward_card(&contract.reward_card);
 
         self.active_contract = None;
-        self.generate_offered_contracts();
+        self.refill_contract_market();
 
         Some(contract)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,17 @@ use rocket_okapi::swagger_ui::{make_swagger_ui, SwaggerUIConfig};
 pub mod action_log;
 pub mod config;
 pub mod config_loader;
+pub mod contract_generation;
 pub mod endpoints;
 pub mod game_state;
 pub mod starter_cards;
 pub mod types;
 pub mod version;
 
-use crate::endpoints::{get_actions_history, get_state, post_action};
+use crate::endpoints::{get_actions_history, get_contracts_available, get_state, post_action};
 use crate::endpoints::{
-    okapi_add_operation_for_get_actions_history_, okapi_add_operation_for_get_state_,
-    okapi_add_operation_for_post_action_,
+    okapi_add_operation_for_get_actions_history_, okapi_add_operation_for_get_contracts_available_,
+    okapi_add_operation_for_get_state_, okapi_add_operation_for_post_action_,
 };
 use crate::game_state::GameState;
 use crate::version::get_version;
@@ -41,7 +42,13 @@ pub fn rocket_initialize() -> rocket::Rocket<rocket::Build> {
         .manage(game_state)
         .mount(
             "/",
-            openapi_get_routes![get_version, post_action, get_state, get_actions_history,],
+            openapi_get_routes![
+                get_version,
+                post_action,
+                get_state,
+                get_actions_history,
+                get_contracts_available,
+            ],
         )
         .mount("/swagger", make_swagger_ui(&swagger_config()))
 }

--- a/tests/contract_system_test.rs
+++ b/tests/contract_system_test.rs
@@ -1,0 +1,412 @@
+//! Integration tests for the Phase 3 contract system.
+//!
+//! Validates formula-based contract generation, market mechanics,
+//! reward card previews, and the `/contracts/available` endpoint.
+
+use my_little_factory_manager::rocket_initialize;
+use rocket::http::{ContentType, Status};
+use rocket::local::blocking::Client;
+
+fn client() -> Client {
+    Client::tracked(rocket_initialize()).expect("valid rocket instance")
+}
+
+fn post_action(client: &Client, json: &str) -> serde_json::Value {
+    let response = client
+        .post("/action")
+        .header(ContentType::JSON)
+        .body(json)
+        .dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json")
+}
+
+fn get_state(client: &Client) -> serde_json::Value {
+    let response = client.get("/state").dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json")
+}
+
+fn get_contracts_available(client: &Client) -> serde_json::Value {
+    let response = client.get("/contracts/available").dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json")
+}
+
+fn detail(result: &serde_json::Value) -> &serde_json::Value {
+    &result["detail"]
+}
+
+fn token_amount(state: &serde_json::Value, token_type_json: &str) -> u64 {
+    let expected: serde_json::Value =
+        serde_json::from_str(token_type_json).expect("valid token_type json");
+    state["tokens"]
+        .as_array()
+        .expect("tokens array")
+        .iter()
+        .find(|entry| entry["token_type"] == expected)
+        .map(|entry| entry["amount"].as_u64().unwrap_or(0))
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Market structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn market_has_three_tier1_contracts_on_start() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state = get_state(&client);
+    let tiers = state["offered_contracts"]
+        .as_array()
+        .expect("offered_contracts");
+    assert_eq!(tiers.len(), 1, "should have exactly 1 tier group");
+    assert_eq!(tiers[0]["tier"], 1);
+
+    let contracts = tiers[0]["contracts"].as_array().expect("contracts array");
+    assert_eq!(contracts.len(), 3, "should offer 3 contracts per tier");
+}
+
+// ---------------------------------------------------------------------------
+// Contract structure validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tier1_contracts_have_valid_requirements() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state = get_state(&client);
+    let contracts = state["offered_contracts"][0]["contracts"]
+        .as_array()
+        .expect("contracts array");
+
+    for (i, contract) in contracts.iter().enumerate() {
+        let reqs = contract["requirements"]
+            .as_array()
+            .expect("requirements array");
+        assert_eq!(
+            reqs.len(),
+            1,
+            "tier 1 contract {} should have exactly 1 requirement",
+            i
+        );
+
+        assert_eq!(
+            reqs[0]["requirement_type"], "OutputThreshold",
+            "contract {} requirement should be OutputThreshold",
+            i
+        );
+        assert_eq!(
+            reqs[0]["token_type"], "ProductionUnit",
+            "contract {} should require ProductionUnit",
+            i
+        );
+
+        let min_amount = reqs[0]["min_amount"].as_u64().expect("min_amount");
+        assert!(
+            (5..=15).contains(&min_amount),
+            "contract {} min_amount {} should be in [5, 15]",
+            i,
+            min_amount
+        );
+    }
+}
+
+#[test]
+fn tier1_reward_cards_match_requirements() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state = get_state(&client);
+    let contracts = state["offered_contracts"][0]["contracts"]
+        .as_array()
+        .expect("contracts array");
+
+    for (i, contract) in contracts.iter().enumerate() {
+        let reqs = contract["requirements"]
+            .as_array()
+            .expect("requirements array");
+        let reward = &contract["reward_card"];
+        let effects = reward["effects"].as_array().expect("effects array");
+
+        assert_eq!(
+            effects.len(),
+            reqs.len(),
+            "contract {} reward card should have same number of effects as requirements",
+            i
+        );
+
+        let tags = reward["tags"].as_array().expect("tags array");
+        assert!(
+            tags.contains(&serde_json::json!("Production")),
+            "contract {} reward card should have Production tag",
+            i
+        );
+
+        for (j, effect) in effects.iter().enumerate() {
+            assert!(
+                effect["inputs"].as_array().expect("inputs").is_empty(),
+                "contract {} effect {} should be pure production (no inputs)",
+                i,
+                j
+            );
+
+            let outputs = effect["outputs"].as_array().expect("outputs");
+            assert_eq!(outputs.len(), 1);
+            assert_eq!(outputs[0]["token_type"], "ProductionUnit");
+
+            let amount = outputs[0]["amount"].as_u64().expect("amount");
+            assert!(
+                (1..=3).contains(&amount),
+                "contract {} effect {} production amount {} should be in [1, 3]",
+                i,
+                j,
+                amount
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Market mechanics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accepting_contract_reduces_market_by_one() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state_before = get_state(&client);
+    let count_before = state_before["offered_contracts"][0]["contracts"]
+        .as_array()
+        .expect("contracts")
+        .len();
+    assert_eq!(count_before, 3);
+
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    let state_after = get_state(&client);
+    let count_after = state_after["offered_contracts"][0]["contracts"]
+        .as_array()
+        .expect("contracts")
+        .len();
+    assert_eq!(
+        count_after, 2,
+        "market should have 2 contracts after accepting 1"
+    );
+}
+
+#[test]
+fn market_refills_after_contract_completion() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":100}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    // Complete the contract
+    let mut completed = false;
+    for _ in 0..100 {
+        let result = post_action(&client, r#"{"action_type":"PlayCard","hand_index":0}"#);
+        if detail(&result)["contract_completed"].is_object() {
+            completed = true;
+            break;
+        }
+    }
+    assert!(completed, "contract should complete");
+
+    let state = get_state(&client);
+    let contracts = state["offered_contracts"][0]["contracts"]
+        .as_array()
+        .expect("contracts");
+    assert_eq!(
+        contracts.len(),
+        3,
+        "market should refill to 3 contracts after completion"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Contracts available endpoint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contracts_available_matches_state() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state = get_state(&client);
+    let available = get_contracts_available(&client);
+
+    assert_eq!(
+        state["offered_contracts"], available,
+        "GET /contracts/available should match state's offered_contracts"
+    );
+}
+
+#[test]
+fn contracts_available_updates_after_accept() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    let available = get_contracts_available(&client);
+    let contracts = available[0]["contracts"].as_array().expect("contracts");
+    assert_eq!(
+        contracts.len(),
+        2,
+        "available should reflect accepted contract"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic generation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_seed_generates_identical_contracts() {
+    let client = client();
+
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    let contracts1 = get_contracts_available(&client);
+
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    let contracts2 = get_contracts_available(&client);
+
+    assert_eq!(
+        contracts1, contracts2,
+        "same seed should generate identical contracts"
+    );
+}
+
+#[test]
+fn different_seeds_generate_different_contracts() {
+    let client = client();
+
+    post_action(&client, r#"{"action_type":"NewGame","seed":111}"#);
+    let contracts1 = get_contracts_available(&client);
+
+    post_action(&client, r#"{"action_type":"NewGame","seed":222}"#);
+    let contracts2 = get_contracts_available(&client);
+
+    assert_ne!(
+        contracts1, contracts2,
+        "different seeds should generate different contracts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-seed validation (fuzz across seeds)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_generated_contracts_are_valid_across_seeds() {
+    let client = client();
+
+    for seed in [1, 42, 100, 999, 12345, 99999] {
+        post_action(
+            &client,
+            &format!(r#"{{"action_type":"NewGame","seed":{seed}}}"#),
+        );
+
+        let state = get_state(&client);
+        let tiers = state["offered_contracts"]
+            .as_array()
+            .expect("offered_contracts");
+
+        assert!(!tiers.is_empty(), "seed {} should have tier groups", seed);
+
+        for tier_group in tiers {
+            let contracts = tier_group["contracts"].as_array().expect("contracts array");
+            assert_eq!(
+                contracts.len(),
+                3,
+                "seed {} should have 3 contracts per tier",
+                seed
+            );
+
+            for contract in contracts {
+                let reqs = contract["requirements"].as_array().expect("requirements");
+                assert!(
+                    !reqs.is_empty(),
+                    "seed {} contract should have requirements",
+                    seed
+                );
+
+                let reward = &contract["reward_card"];
+                let effects = reward["effects"].as_array().expect("effects");
+                assert_eq!(
+                    effects.len(),
+                    reqs.len(),
+                    "seed {} reward effects should match requirement count",
+                    seed
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reward card is awarded on completion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reward_card_added_to_library_on_completion() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":100}"#);
+
+    let state_before = get_state(&client);
+    let cards_before: usize = state_before["cards"]
+        .as_array()
+        .expect("cards")
+        .iter()
+        .map(|e| e["counts"]["library"].as_u64().unwrap_or(0) as usize)
+        .sum();
+
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    let mut completed = false;
+    for _ in 0..100 {
+        let result = post_action(&client, r#"{"action_type":"PlayCard","hand_index":0}"#);
+        if detail(&result)["contract_completed"].is_object() {
+            completed = true;
+            break;
+        }
+    }
+    assert!(completed, "contract should complete");
+
+    let state_after = get_state(&client);
+    let cards_after: usize = state_after["cards"]
+        .as_array()
+        .expect("cards")
+        .iter()
+        .map(|e| e["counts"]["library"].as_u64().unwrap_or(0) as usize)
+        .sum();
+
+    assert_eq!(
+        cards_after,
+        cards_before + 1,
+        "completing a contract should add 1 reward card to the library"
+    );
+
+    assert_eq!(
+        token_amount(&state_after, r#"{"ContractsTierCompleted":1}"#),
+        1
+    );
+}

--- a/tests/game_loop_test.rs
+++ b/tests/game_loop_test.rs
@@ -126,10 +126,14 @@ fn accept_contract_activates_offered_contract() {
 
     let state_after = get_state(&client);
     assert!(state_after["active_contract"].is_object());
-    assert!(state_after["offered_contracts"]
+    let remaining = state_after["offered_contracts"][0]["contracts"]
         .as_array()
-        .expect("offered_contracts")
-        .is_empty());
+        .expect("contracts");
+    assert_eq!(
+        remaining.len(),
+        2,
+        "should have 2 remaining contracts after accepting 1"
+    );
     assert_eq!(state_after["active_contract"], offered);
 }
 

--- a/tests/types_serialization_test.rs
+++ b/tests/types_serialization_test.rs
@@ -376,6 +376,22 @@ fn load_custom_game_rules_json() {
             "contracts_per_tier_to_advance": 5,
             "contract_market_size_per_tier": 4,
             "discard_production_unit_bonus": 2
+        },
+        "contract_formulas": {
+            "output_threshold": {
+                "min_tier": 1,
+                "base_min": 4,
+                "base_max": 10,
+                "per_tier_min": 1,
+                "per_tier_max": 5
+            },
+            "reward_production": {
+                "min_tier": 1,
+                "base_min": 0,
+                "base_max": 1,
+                "per_tier_min": 1,
+                "per_tier_max": 2
+            }
         }
     }"#;
     let config = load_game_rules_from_json(json).expect("parse custom game rules");


### PR DESCRIPTION
## Summary

Replaces the placeholder single-contract generator with a formula-based contract system supporting arbitrary tiers.

### What changed

**New module: `src/contract_generation.rs`**
- `TierScalingFormula`: `value = roll(base_min + tier × per_tier_min, base_max + tier × per_tier_max)`
- Formula-driven contract and reward card generation
- `min_tier` gating for progressive type introduction

**Config expansion**
- `ContractFormulasConfig` and `TierScalingFormula` structs in `src/config.rs`
- `contract_formulas` section in `game_rules.json` with `output_threshold` and `reward_production` formulas

**Market mechanics in `src/game_state.rs`**
- `refill_contract_market()` — fills missing slots per unlocked tier (additive, not regenerate)
- `unlocked_tiers()` — tier 1 always unlocked; higher tiers via `ContractsTierCompleted` tokens
- 3 contracts per tier (configurable via `contract_market_size_per_tier`)

**New endpoint**
- `GET /contracts/available` — dedicated contracts endpoint

**Tier 1 specifics**
- 1 requirement: `OutputThreshold(ProductionUnit)` in [5, 15]
- 1 reward effect: `PureProduction(ProductionUnit)` in [1, 3] (matches starter deck range)
- No abandon action — contracts auto-complete or auto-fail (auto-fail only for future tiers)

### Tests
- 11 new integration tests in `tests/contract_system_test.rs`
- All 63 tests pass, 89% line coverage
- Fixed existing tests for 3-contract market

### BREAKING
- Contract market now offers 3 contracts per tier instead of 1
- `GameRulesConfig` requires `contract_formulas` field

### Phase 6 compatibility
- Multi-tier infrastructure ready — just add new formula entries with higher `min_tier`
- Requirement count scales: tier 2 → 1–3, tier 3 → 2–4, etc.