### PR TITLE
feat: Phase 10.1 — simulation framework and SimpleFirstStrategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,13 @@ rand_pcg = { version = "0.3", features = ["serde1"] }
 log = "0.4"
 env_logger = "0.10"
 
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
 [features]
 simulation = []
+
+[[test]]
+name = "simulation"
+path = "tests/simulation/main.rs"
+required-features = ["simulation"]

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -287,12 +287,7 @@ The existing [my_little_card_game](https://github.com/RobbingDaHood/my_little_ca
 
 **Goal**: Fine-tune the game so that simple, repetitive strategies perform measurably worse than adaptive, multi-dimensional strategies. Ensure the difficulty curve feels fair and purposeful across all tiers.
 
-**Deliverables**:
-- Playtesting sessions to identify degenerate strategies (e.g., pure production spam, single-tag dominance)
-- Tune adaptive balance parameters (`alpha`, `decay_rate`, `failure_relaxation`, `max_tightening_pct`, `max_increase_pct`, `normalization_factor`) so a single dominant strategy creates noticeably harder contracts within 5–10 contracts
-- Add balance tests: repeated single-strategy simulations should produce measurably rising pressure and harder contract requirements
-- Review TurnWindow and CardTagConstraint balance: ensure they are genuinely challenging without being arbitrary punishments
-- Update designer docs, hints, and vision if balance changes affect documented behavior
+**Success metric**: Total actions from game start to first contract completion at milestone tiers 10, 20, 30, 40, and 50 (0-indexed). Measured by automated strategy simulation tests under `tests/simulation/` (run with `cargo test --features simulation --test simulation --release -- --nocapture`).
 
 **Known limitation of current pressure model**: The current pressure signal tracks gross token production per token type. In a well-developed deck, most token types will be in regular use simultaneously — so nearly all token pressures grow together. The system may behave more like a global difficulty escalator than a targeted strategy-detection mechanism, tightening requirements on nearly all tokens at once rather than selectively penalizing the dominant strategy.
 
@@ -301,6 +296,74 @@ The existing [my_little_card_game](https://github.com/RobbingDaHood/my_little_ca
 - Compute a dominance score for the leading tag (e.g., Gini coefficient or top-tag share vs total)
 - Apply elevated pressure only to requirements associated with the dominant strategy, not uniformly across all tokens
 - This correctly distinguishes "spam Production cards" from a balanced mixed approach and provides targeted resistance
+
+---
+
+### Phase 10.1 — Simulation Infrastructure & SimpleFirst Strategy ✅
+
+**Goal**: Create the simulation framework and one simple strategy. Report how far it gets at each tier milestone, and what blocks it.
+
+**Deliverables**:
+- `tests/simulation/` — simulation test binary (feature-gated: `--features simulation`)
+  - `game_driver.rs` — drives game sessions via in-process Rocket test client
+  - `runner.rs` — runs multiple seeds, aggregates milestone stats
+  - `strategies/mod.rs` — `Strategy` trait
+  - `strategies/simple_first.rs` — `SimpleFirstStrategy`
+  - `main.rs` — `#[test]` entry point with soft blocker reporting
+- `docs/design/roadmap.md` — this file updated with Phase 10 sub-phases
+
+**SimpleFirstStrategy behaviour**: always accepts the highest available tier contract, plays the first valid card, discards when no card can be played, never deckbuilds.
+
+**Finding from Phase 10.1**: `SimpleFirstStrategy` reaches **tier 3** and stalls permanently. After completing ~30–40 contracts (tiers 0–3), it accepts a contract whose token requirements the starter deck cannot fulfill. Because no `TurnWindow` constraint exists before tier 6, the contract neither completes nor fails — the game loop runs indefinitely on that single contract. This reveals two balance issues to address in Phase 10.5: (1) the starter deck should provide at least a minimal path through early tiers, and (2) a TurnWindow should apply at all tiers so uncompletable contracts eventually time out.
+
+---
+
+### Phase 10.2 — Multiple Simple Strategies
+
+**Goal**: Add 2–3 more simple strategies for comparison. Each reads only `possible_actions`, applies no contract-aware heuristics, and never deckbuilds.
+
+**Strategies to add**:
+- `RandomStrategy` — picks uniformly at random from all valid actions (seeded RNG for reproducibility)
+- `MaxProductionStrategy` — plays the card with the highest total output token production (by index as a tie-breaker); falls back to random
+- `AlwaysDiscardStrategy` — always discards instead of playing (worst-case baseline)
+
+**Expected outcome**: All simple strategies stall in the same tier range (0–5). `RandomStrategy` ≈ `SimpleFirst`; `MaxProduction` slightly better; `AlwaysDiscard` much worse or never advances.
+
+---
+
+### Phase 10.3 — First Advanced Strategy
+
+**Goal**: One strategy that reads contract requirements and makes smarter decisions.
+
+**Strategy: `ContractAwareStrategy`**:
+- Reads active contract token requirements from `GET /state`
+- Prefers cards that produce tokens the active contract needs
+- Avoids cards whose production would trigger `HarmfulTokenLimitExceeded`
+- Performs deckbuilding: replaces starter cards with reward cards between contracts
+
+**Expected outcome**: Reaches higher tiers than all simple strategies; demonstrates that the game is beatable with informed play.
+
+---
+
+### Phase 10.4 — Multiple Advanced Strategies
+
+**Additional advanced strategies**:
+- `TierFocusStrategy` — always accepts the highest available tier contract, reads requirements, prioritises matching cards
+- `SafePlayStrategy` — monitors harmful token levels vs. contract limits; discards instead of playing cards that would cause failures
+- `DeckbuilderStrategy` — extends `ContractAware` with aggressive deckbuilding: prioritises reward cards that unlock new token types
+
+---
+
+### Phase 10.5 — Iterative Balancing
+
+**Goal**: Use simulation results to tune adaptive balance parameters and verify the intended strategy hierarchy.
+
+**Balancing targets**:
+- Simple strategies should reach noticeably lower tiers per unit of actions than advanced strategies
+- Advanced strategies should show measurably better tier-milestone action counts (≥20% faster to tier 20+)
+- Parameters to tune: `alpha`, `decay_rate`, `failure_relaxation`, `max_tightening_pct`, `max_increase_pct`, `normalization_factor` in `game_rules.json`
+- Address Phase 10.1 finding: add `TurnWindow` constraints at all tiers (not just tier 6+) so no contract can run indefinitely
+- Add regression assertions once a good balance point is found (similar to card game's win-rate band assertions)
 
 ---
 

--- a/tests/simulation/game_driver.rs
+++ b/tests/simulation/game_driver.rs
@@ -1,0 +1,175 @@
+use std::collections::{HashMap, HashSet};
+
+use my_little_factory_manager::rocket_initialize;
+use rocket::http::ContentType;
+use rocket::local::blocking::Client;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::strategies::Strategy;
+
+/// A point-in-time snapshot passed to the strategy for decision-making.
+pub struct GameSnapshot {
+    /// Full game state from `GET /state`.
+    pub state: Value,
+    /// Available actions with NewGame filtered out, from `GET /actions/possible`.
+    pub possible_actions: Vec<Value>,
+}
+
+/// Total actions taken when the first contract at a specific milestone tier was completed.
+#[derive(Debug, Clone, Serialize)]
+pub struct MilestoneResult {
+    pub tier: u32,
+    pub actions_to_reach: u64,
+}
+
+/// Results from one complete simulated game.
+#[derive(Debug, Clone, Serialize)]
+pub struct GameResult {
+    pub seed: u64,
+    pub milestones: Vec<MilestoneResult>,
+    pub max_tier_reached: Option<u32>,
+    pub total_actions: u64,
+    pub contracts_completed: u32,
+    pub contracts_failed: u32,
+    /// Count of each contract failure reason observed.
+    pub failure_reasons: HashMap<String, u32>,
+    /// True when max_actions was exhausted before all milestones were reached.
+    pub hit_action_limit: bool,
+    /// True when no non-NewGame actions were available (invariant broken).
+    pub stuck: bool,
+}
+
+impl GameResult {
+    fn new(seed: u64) -> Self {
+        Self {
+            seed,
+            milestones: Vec::new(),
+            max_tier_reached: None,
+            total_actions: 0,
+            contracts_completed: 0,
+            contracts_failed: 0,
+            failure_reasons: HashMap::new(),
+            hit_action_limit: false,
+            stuck: false,
+        }
+    }
+}
+
+/// Drives one game session from `NewGame` until all milestones are reached or
+/// the action budget is exhausted.
+pub struct GameDriver {
+    pub max_actions: u64,
+    pub milestone_tiers: Vec<u32>,
+}
+
+impl GameDriver {
+    pub fn new(max_actions: u64, milestone_tiers: Vec<u32>) -> Self {
+        Self {
+            max_actions,
+            milestone_tiers,
+        }
+    }
+
+    pub fn play_game(&self, seed: u64, strategy: &dyn Strategy) -> GameResult {
+        let client = Client::tracked(rocket_initialize()).expect("valid rocket");
+
+        let new_game_action = json!({"action_type": "NewGame", "seed": seed});
+        post_action(&client, &new_game_action);
+
+        let mut result = GameResult::new(seed);
+        let milestone_set: HashSet<u32> = self.milestone_tiers.iter().cloned().collect();
+        let mut reached_milestones: HashSet<u32> = HashSet::new();
+
+        loop {
+            let all_possible = get_possible_actions(&client);
+
+            // NewGame is always listed but must not be chosen during an active session.
+            let non_new_game: Vec<Value> = all_possible
+                .into_iter()
+                .filter(|a| a["action_type"] != "NewGame")
+                .collect();
+
+            if non_new_game.is_empty() {
+                result.stuck = true;
+                break;
+            }
+
+            let state = if strategy.needs_state() {
+                get_state(&client)
+            } else {
+                Value::Null
+            };
+            let snapshot = GameSnapshot {
+                state,
+                possible_actions: non_new_game.clone(),
+            };
+
+            let action = strategy.choose_action(&non_new_game, &snapshot);
+            result.total_actions += 1;
+
+            let response = post_action(&client, &action);
+
+            if response["outcome"] == "Success" {
+                let resolution = &response["detail"]["contract_resolution"];
+                match resolution["resolution_type"].as_str() {
+                    Some("Completed") => {
+                        let tier = resolution["contract"]["tier"].as_u64().unwrap_or(0) as u32;
+                        result.contracts_completed += 1;
+                        result.max_tier_reached =
+                            Some(result.max_tier_reached.map_or(tier, |t: u32| t.max(tier)));
+
+                        if milestone_set.contains(&tier) && !reached_milestones.contains(&tier) {
+                            reached_milestones.insert(tier);
+                            result.milestones.push(MilestoneResult {
+                                tier,
+                                actions_to_reach: result.total_actions,
+                            });
+                        }
+                    }
+                    Some("Failed") => {
+                        result.contracts_failed += 1;
+                        let failure_type = resolution["reason"]["failure_type"]
+                            .as_str()
+                            .unwrap_or("Unknown")
+                            .to_string();
+                        *result.failure_reasons.entry(failure_type).or_insert(0) += 1;
+                    }
+                    _ => {}
+                }
+            }
+
+            if reached_milestones.len() == self.milestone_tiers.len() {
+                break;
+            }
+            if result.total_actions >= self.max_actions {
+                result.hit_action_limit = true;
+                break;
+            }
+        }
+
+        result
+    }
+}
+
+fn post_action(client: &Client, action: &Value) -> Value {
+    let response = client
+        .post("/action")
+        .header(ContentType::JSON)
+        .body(action.to_string())
+        .dispatch();
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json response from /action")
+}
+
+fn get_state(client: &Client) -> Value {
+    let response = client.get("/state").dispatch();
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json from /state")
+}
+
+fn get_possible_actions(client: &Client) -> Vec<Value> {
+    let response = client.get("/actions/possible").dispatch();
+    let body = response.into_string().expect("response body");
+    serde_json::from_str::<Vec<Value>>(&body).expect("valid json array from /actions/possible")
+}

--- a/tests/simulation/main.rs
+++ b/tests/simulation/main.rs
@@ -1,0 +1,81 @@
+//! Simulation test suite — strategy-driven automated gameplay.
+//!
+//! Compile and run with:
+//!   cargo test --features simulation --test simulation -- --nocapture
+//!
+//! These tests are intentionally opt-in and not part of the standard `make check`
+//! run because each game can require tens of thousands of actions.
+
+#![cfg(feature = "simulation")]
+#![allow(dead_code)]
+
+mod game_driver;
+mod runner;
+mod strategies;
+
+use runner::{SimulationConfig, SimulationRunner};
+use strategies::simple_first::SimpleFirstStrategy;
+
+/// Runs SimpleFirstStrategy across multiple seeds and reports tier-milestone
+/// performance.  The strategy never deckbuilds and makes no attempt to manage
+/// harmful tokens — it exists purely to reveal how far naive play can reach and
+/// what the earliest blockers are.
+///
+/// Hard assertions (test failure):
+///   - At least one game reaches tier 2 (proves the basic game loop works end-to-end)
+///
+/// Soft observations (printed, not asserted):
+///   - Milestone reach rates and mean action counts for tiers 10/20/30/40/50
+///   - Dominant failure reasons at the tier where progress stalls
+#[test]
+fn simple_first_strategy_progression() {
+    let strategy = SimpleFirstStrategy::new();
+    let config = SimulationConfig {
+        games_per_strategy: 3,
+        base_seed: 42,
+        max_actions_per_game: 2_000_000,
+        milestone_tiers: vec![10, 20, 30, 40, 50],
+    };
+
+    let runner = SimulationRunner::new(config);
+    let report = runner.run_strategy(&strategy);
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("report serialisable")
+    );
+
+    // Hard assertion: game loop is functional
+    assert!(
+        report.overall_max_tier.is_some_and(|t| t >= 2),
+        "SimpleFirstStrategy should reach at least tier 2; max tier reached: {:?}. \
+         This indicates a broken game loop, not just a weak strategy.",
+        report.overall_max_tier,
+    );
+
+    // Inform developer when the strategy stalls before tier 50
+    if report.overall_max_tier.is_none_or(|t| t < 50) {
+        eprintln!(
+            "\nSimpleFirstStrategy did not reach tier 50.\n\
+             Max tier: {:?}\n\
+             Top failure reasons: {:?}\n\
+             Suggestion: a simple strategy is expected to stall due to harmful \
+             token accumulation (no waste-removal cards in starter deck) and the \
+             lack of deckbuilding. This is informational — see Phase 10.2+ for \
+             strategies that handle these mechanics.",
+            report.overall_max_tier, report.top_failure_reasons,
+        );
+    }
+
+    // Log unreached milestones
+    for milestone in &report.milestones {
+        if milestone.reach_rate < 1.0 {
+            eprintln!(
+                "Milestone tier {}: reach rate {:.0}% (mean actions: {:?})",
+                milestone.tier,
+                milestone.reach_rate * 100.0,
+                milestone.mean_actions,
+            );
+        }
+    }
+}

--- a/tests/simulation/runner.rs
+++ b/tests/simulation/runner.rs
@@ -1,0 +1,165 @@
+use std::cmp::Reverse;
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use crate::game_driver::{GameDriver, GameResult};
+use crate::strategies::Strategy;
+
+/// Configuration for a simulation run.
+#[derive(Debug, Clone)]
+pub struct SimulationConfig {
+    pub games_per_strategy: u32,
+    pub base_seed: u64,
+    pub max_actions_per_game: u64,
+    pub milestone_tiers: Vec<u32>,
+}
+
+impl Default for SimulationConfig {
+    fn default() -> Self {
+        Self {
+            games_per_strategy: 3,
+            base_seed: 42,
+            max_actions_per_game: 200_000,
+            milestone_tiers: vec![10, 20, 30, 40, 50],
+        }
+    }
+}
+
+/// Aggregated statistics for a single milestone tier across all simulated games.
+#[derive(Debug, Clone, Serialize)]
+pub struct MilestoneStats {
+    pub tier: u32,
+    /// Fraction of games that completed a contract at this tier (0.0–1.0).
+    pub reach_rate: f64,
+    /// Mean total actions to first completion at this tier, over games that reached it.
+    /// None if no game reached this milestone.
+    pub mean_actions: Option<f64>,
+}
+
+/// Aggregated simulation report for one strategy.
+#[derive(Debug, Serialize)]
+pub struct StrategyReport {
+    pub strategy_name: String,
+    pub games_run: u32,
+    pub milestones: Vec<MilestoneStats>,
+    pub overall_max_tier: Option<u32>,
+    pub total_contracts_completed: u64,
+    pub total_contracts_failed: u64,
+    /// Top contract failure reasons sorted by frequency (descending).
+    pub top_failure_reasons: Vec<(String, u64)>,
+    pub stuck_games: u32,
+    pub action_limit_games: u32,
+}
+
+/// Runs multiple seeds for a strategy and aggregates results into a `StrategyReport`.
+pub struct SimulationRunner {
+    pub config: SimulationConfig,
+}
+
+impl SimulationRunner {
+    pub fn new(config: SimulationConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn run_strategy(&self, strategy: &dyn Strategy) -> StrategyReport {
+        let driver = GameDriver::new(
+            self.config.max_actions_per_game,
+            self.config.milestone_tiers.clone(),
+        );
+
+        let mut all_results: Vec<GameResult> = Vec::new();
+
+        for i in 0..self.config.games_per_strategy {
+            let seed = self.config.base_seed + u64::from(i);
+            eprintln!(
+                "[{}] seed {} ({}/{})...",
+                strategy.name(),
+                seed,
+                i + 1,
+                self.config.games_per_strategy
+            );
+            let result = driver.play_game(seed, strategy);
+            eprintln!(
+                "  max_tier={:?} completed={} failed={} actions={}{}",
+                result.max_tier_reached,
+                result.contracts_completed,
+                result.contracts_failed,
+                result.total_actions,
+                if result.hit_action_limit {
+                    " [LIMIT]"
+                } else {
+                    ""
+                },
+            );
+            all_results.push(result);
+        }
+
+        self.aggregate(strategy.name(), all_results)
+    }
+
+    fn aggregate(&self, name: &str, results: Vec<GameResult>) -> StrategyReport {
+        let games_run = results.len() as u32;
+
+        let milestones: Vec<MilestoneStats> = self
+            .config
+            .milestone_tiers
+            .iter()
+            .map(|&tier| {
+                let reached: Vec<u64> = results
+                    .iter()
+                    .filter_map(|r| {
+                        r.milestones
+                            .iter()
+                            .find(|m| m.tier == tier)
+                            .map(|m| m.actions_to_reach)
+                    })
+                    .collect();
+                let reach_rate = reached.len() as f64 / games_run as f64;
+                let mean_actions = if reached.is_empty() {
+                    None
+                } else {
+                    Some(reached.iter().sum::<u64>() as f64 / reached.len() as f64)
+                };
+                MilestoneStats {
+                    tier,
+                    reach_rate,
+                    mean_actions,
+                }
+            })
+            .collect();
+
+        let overall_max_tier = results.iter().filter_map(|r| r.max_tier_reached).max();
+
+        let total_contracts_completed: u64 = results
+            .iter()
+            .map(|r| u64::from(r.contracts_completed))
+            .sum();
+        let total_contracts_failed: u64 =
+            results.iter().map(|r| u64::from(r.contracts_failed)).sum();
+
+        let mut failure_totals: HashMap<String, u64> = HashMap::new();
+        for result in &results {
+            for (reason, &count) in &result.failure_reasons {
+                *failure_totals.entry(reason.clone()).or_insert(0) += u64::from(count);
+            }
+        }
+        let mut top_failure_reasons: Vec<(String, u64)> = failure_totals.into_iter().collect();
+        top_failure_reasons.sort_by_key(|a| Reverse(a.1));
+
+        let stuck_games = results.iter().filter(|r| r.stuck).count() as u32;
+        let action_limit_games = results.iter().filter(|r| r.hit_action_limit).count() as u32;
+
+        StrategyReport {
+            strategy_name: name.to_string(),
+            games_run,
+            milestones,
+            overall_max_tier,
+            total_contracts_completed,
+            total_contracts_failed,
+            top_failure_reasons,
+            stuck_games,
+            action_limit_games,
+        }
+    }
+}

--- a/tests/simulation/strategies/mod.rs
+++ b/tests/simulation/strategies/mod.rs
@@ -1,0 +1,21 @@
+use serde_json::Value;
+
+use crate::game_driver::GameSnapshot;
+
+pub mod simple_first;
+
+/// A pluggable gameplay strategy for simulation.
+///
+/// Receives only the actions the game considers valid (NewGame is excluded).
+/// Returns a single action value ready to POST to `/action`.
+pub trait Strategy {
+    fn name(&self) -> &str;
+    fn choose_action(&self, possible_actions: &[Value], snapshot: &GameSnapshot) -> Value;
+
+    /// Return `true` if this strategy requires `snapshot.state` to be populated.
+    /// Defaults to `false` — avoids an extra `GET /state` per action for simple
+    /// strategies that only inspect `possible_actions`.
+    fn needs_state(&self) -> bool {
+        false
+    }
+}

--- a/tests/simulation/strategies/simple_first.rs
+++ b/tests/simulation/strategies/simple_first.rs
@@ -1,0 +1,87 @@
+use serde_json::{json, Value};
+
+use crate::game_driver::GameSnapshot;
+use crate::strategies::Strategy;
+
+/// The simplest possible strategy:
+/// - Accepts the highest available tier contract (last in valid_tiers list)
+/// - Always plays the first valid card
+/// - Discards only when no card can be played
+/// - Never deckbuilds (ignores ReplaceCard)
+///
+/// Picking the highest tier ensures the strategy actually attempts to advance
+/// through tier milestones. It remains simple because it reads nothing from
+/// game state and applies no card selection heuristics.  It intentionally
+/// makes no attempt to manage harmful tokens, respect turn windows, or
+/// optimise for contract requirements, which reveals the earliest tier where
+/// the game mechanics become unforgiving for naive play.
+pub struct SimpleFirstStrategy;
+
+impl SimpleFirstStrategy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Strategy for SimpleFirstStrategy {
+    fn name(&self) -> &str {
+        "simple_first"
+    }
+
+    fn choose_action(&self, possible_actions: &[Value], _snapshot: &GameSnapshot) -> Value {
+        // 1. Play the first valid card if a contract is active
+        if let Some(play) = possible_actions
+            .iter()
+            .find(|a| a["action_type"] == "PlayCard")
+        {
+            if let Some(indices) = play["valid_card_indices"].as_array() {
+                if let Some(first) = indices.first() {
+                    return json!({
+                        "action_type": "PlayCard",
+                        "card_index": first
+                    });
+                }
+            }
+        }
+
+        // 2. Accept the highest available tier contract (furthest progression)
+        if let Some(accept) = possible_actions
+            .iter()
+            .find(|a| a["action_type"] == "AcceptContract")
+        {
+            if let Some(tiers) = accept["valid_tiers"].as_array() {
+                if let Some(highest_tier) = tiers.last() {
+                    let tier_index = highest_tier["tier_index"].as_u64().unwrap_or(0);
+                    let contract_index = highest_tier["valid_contract_index_range"]["min"]
+                        .as_u64()
+                        .unwrap_or(0);
+                    return json!({
+                        "action_type": "AcceptContract",
+                        "tier_index": tier_index,
+                        "contract_index": contract_index
+                    });
+                }
+            }
+        }
+
+        // 3. Discard the first card when no card can be played
+        if let Some(discard) = possible_actions
+            .iter()
+            .find(|a| a["action_type"] == "DiscardCard")
+        {
+            if let Some(indices) = discard["valid_card_indices"].as_array() {
+                if let Some(first) = indices.first() {
+                    return json!({
+                        "action_type": "DiscardCard",
+                        "card_index": first
+                    });
+                }
+            }
+        }
+
+        panic!(
+            "SimpleFirstStrategy: no actionable option found in {:?}",
+            possible_actions
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Splits roadmap Phase 10 into five concrete sub-phases (10.1–10.5) and implements Phase 10.1: an opt-in simulation test binary driven by `--features simulation`.

## What changed

### Simulation infrastructure (`tests/simulation/`)
- **`game_driver.rs`** — drives game sessions via in-process Rocket test client; tracks milestones, failure reasons, and stuck/limit states
- **`runner.rs`** — runs multiple seeds, aggregates reach rates and mean action counts per milestone tier
- **`strategies/mod.rs`** — `Strategy` trait with optional `needs_state()` to avoid unnecessary `GET /state` calls
- **`strategies/simple_first.rs`** — `SimpleFirstStrategy`: always accepts the highest available tier, plays the first valid card, discards otherwise, never deckbuilds
- **`main.rs`** — `#[test]` entry point with hard assertion (tier ≥ 2) and soft blocker reporting

### Roadmap (`docs/design/roadmap.md`)
Phase 10 replaced with five sub-phases: 10.1 infrastructure (done), 10.2 multiple simple strategies, 10.3 first advanced strategy, 10.4 multiple advanced strategies, 10.5 iterative balancing.

## Finding from Phase 10.1

**SimpleFirstStrategy reaches tier 3 and stalls permanently.**

After completing ~30–40 contracts across tiers 0–3, it accepts a contract whose token requirements the starter deck cannot fulfill. Because no `TurnWindow` constraint exists before tier 6, that contract neither completes nor fails — the game loops forever on it.

This reveals two balance issues to address in **Phase 10.5**:
1. **TurnWindow should apply at all tiers** so uncompletable contracts eventually time out.
2. **Starter deck needs a minimal path** through early tiers without deckbuilding.

## Running the simulation
```bash
cargo test --features simulation --test simulation --release -- --nocapture
```