### PR TITLE
feat: AbandonContract action (#13) and beneficial-token tier-gating (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The game also provides self-documenting endpoints:
 #### Game Actions
 | Endpoint | Purpose |
 |----------|---------|
-| `POST /action` | Submit a player action (NewGame, AcceptContract, PlayCard, DiscardCard, ReplaceCard) |
+| `POST /action` | Submit a player action (NewGame, AcceptContract, PlayCard, DiscardCard, ReplaceCard, AbandonContract) |
 | `GET /actions/possible` | List currently valid actions with index ranges |
 | `GET /actions/history` | Full action history for deterministic replay |
 

--- a/configurations/general/game_rules.json
+++ b/configurations/general/game_rules.json
@@ -4,7 +4,8 @@
         "starting_deck_size": 50,
         "contracts_per_tier_to_advance": 10,
         "contract_market_size_per_tier": 3,
-        "discard_production_unit_bonus": 1
+        "discard_production_unit_bonus": 1,
+        "min_turns_before_abandon": 5
     },
     "contract_formulas": {
         "output_threshold": {

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -312,9 +312,16 @@ The existing [my_little_card_game](https://github.com/RobbingDaHood/my_little_ca
   - `main.rs` — `#[test]` entry point with soft blocker reporting
 - `docs/design/roadmap.md` — this file updated with Phase 10 sub-phases
 
-**SimpleFirstStrategy behaviour**: always accepts the highest available tier contract, plays the first valid card, discards when no card can be played, never deckbuilds.
+**SimpleFirstStrategy behaviour**: always accepts the highest available tier contract, plays the first valid card, discards when no card can be played, uses `AbandonContract` as a last resort when neither play nor discard is possible, never deckbuilds.
 
-**Finding from Phase 10.1**: `SimpleFirstStrategy` reaches **tier 3** and stalls permanently. After completing ~30–40 contracts (tiers 0–3), it accepts a contract whose token requirements the starter deck cannot fulfill. Because no `TurnWindow` constraint exists before tier 6, the contract neither completes nor fails — the game loop runs indefinitely on that single contract. This reveals two balance issues to address in Phase 10.5: (1) the starter deck should provide at least a minimal path through early tiers, and (2) a TurnWindow should apply at all tiers so uncompletable contracts eventually time out.
+**Finding from Phase 10.1 (original)**: `SimpleFirstStrategy` reaches **tier 3** and stalls permanently due to no escape from uncompletable contracts.
+
+**Finding from Phase 10.1 (after Issues #13 and #14)**:
+- Issues #13 (`AbandonContract` action) and #14 (beneficial-token min requirement tier-gating) were implemented.
+- `SimpleFirstStrategy` now reaches **tier 5** with 52–54 contract completions across 3 seeds, hitting the 2M action limit.
+- Zero contract failures, zero abandonments — the strategy completes every contract it starts, but progresses slowly at higher tiers (~38K actions per contract at tier 5).
+- The bottleneck is **action efficiency**, not correctness: the starter deck has ~10% PU-producing cards, so accumulating enough PUs for a tier-5 threshold takes many shuffles.
+- The strategy never reaches tier 10 within 2M actions, confirming that smarter card selection is required for higher-tier progress.
 
 ---
 
@@ -362,8 +369,9 @@ The existing [my_little_card_game](https://github.com/RobbingDaHood/my_little_ca
 - Simple strategies should reach noticeably lower tiers per unit of actions than advanced strategies
 - Advanced strategies should show measurably better tier-milestone action counts (≥20% faster to tier 20+)
 - Parameters to tune: `alpha`, `decay_rate`, `failure_relaxation`, `max_tightening_pct`, `max_increase_pct`, `normalization_factor` in `game_rules.json`
-- Address Phase 10.1 finding: add `TurnWindow` constraints at all tiers (not just tier 6+) so no contract can run indefinitely
 - Add regression assertions once a good balance point is found (similar to card game's win-rate band assertions)
+- **Abandonment rate requirement**: advanced strategies must show near-zero abandonment; simple strategies that frequently abandon must perform measurably worse than those that complete contracts. High abandonment rates are a balance signal — a sign that a requirement class is too tight or the starter deck is missing critical card types.
+- **Action efficiency target for Phase 10.2+**: the `SimpleFirstStrategy` currently takes ~38K actions per tier-5 contract. A `ContractAwareStrategy` that selects PU-producing cards preferentially should reduce this by at least 50%, enabling tier-10+ progress within 2M actions.
 
 ---
 

--- a/docs/design/vision.md
+++ b/docs/design/vision.md
@@ -115,6 +115,14 @@ Contracts are:
 * but always followed by **new opportunities** — the market never runs dry
 * failure does not end progression, only **slows it**
 
+### Emergency Escape — AbandonContract
+
+After a minimum number of turns on a contract (configurable; default 5), the `AbandonContract` action becomes available. This is a last-resort escape for players who are genuinely stuck — for example, all playable cards are banned by tag constraints.
+
+Abandonment counts as a failure: it breaks the streak, increments `total_contracts_failed`, and adds its own `total_contracts_abandoned` counter in metrics. No reward is earned.
+
+**Design principle**: no viable strategy should rely on abandonment. Game balance must ensure that players who frequently abandon perform measurably worse than those who complete contracts. High abandonment rates in simulation are a balance signal that something is wrong — either a requirement class is too tight at a given tier, or the starter deck is missing a critical card type.
+
 ---
 
 ## 🏗 Contract Tier System

--- a/src/action_log.rs
+++ b/src/action_log.rs
@@ -32,6 +32,14 @@ pub enum PlayerAction {
         replacement_card_index: usize,
         sacrifice_card_index: usize,
     },
+    /// Abandon the active contract before it resolves naturally.
+    ///
+    /// Only allowed after at least `min_turns_before_abandon` turns have been
+    /// played on the contract. Abandoning counts as a contract failure in all
+    /// failure metrics and also increments `total_contracts_abandoned`.
+    /// Abandonment is an emergency escape — no well-balanced strategy should
+    /// rely on it routinely.
+    AbandonContract,
 }
 
 /// A single entry in the action log.

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub struct GeneralRules {
     pub contract_market_size_per_tier: u32,
     /// Production units gained when discarding a card for baseline benefit.
     pub discard_production_unit_bonus: u32,
+    /// Minimum turns played on the active contract before AbandonContract is allowed.
+    pub min_turns_before_abandon: u32,
 }
 
 /// Formula parameters for contract and reward card generation.

--- a/src/contract_generation.rs
+++ b/src/contract_generation.rs
@@ -339,16 +339,32 @@ fn unlocked_card_tags(tier: u32, effect_types: &[CardEffectTypeConfig]) -> Vec<C
 
 /// Returns the requirement types available at the given tier, paired with
 /// generator functions. Only uses token types with unlocked card effects.
+///
+/// Beneficial-token minimum requirements are gated two tiers behind the
+/// token's card-effect unlock tier. Because `roll_requirement_tier` may
+/// produce `req_tier = contract_tier + 1`, a one-tier offset is not enough:
+/// a token unlocking at T could still appear via req_tier = T+1. Using
+/// `saturating_sub(2)` ensures tokens only enter the pool at req_tier ≥ T+2,
+/// which is only reachable in contracts at contract_tier ≥ T+1 (one full tier
+/// after unlock). `0.saturating_sub(2) == 0` keeps ProductionUnit in the
+/// tier-0 pool.
+/// Harmful-token maximum requirements use the full current-tier unlock set
+/// because the player can only exceed them by actively playing cards that
+/// produce the harmful token, which are also only unlocked progressively.
 fn available_requirement_generators(
     tier: u32,
     formulas: &ContractFormulasConfig,
     effect_types: &[CardEffectTypeConfig],
 ) -> Vec<RequirementGenerator> {
     let mut generators: Vec<RequirementGenerator> = Vec::new();
-    let available_tokens = unlocked_token_types(tier, effect_types);
 
-    // TokenRequirement generators for each beneficial token that's unlocked
-    for token in &available_tokens {
+    // Beneficial min requirements: two tiers prior. Requirements are generated at
+    // req_tier which can be up to contract_tier + 1, so we need to subtract 2 to
+    // guarantee the token's producer was unlocked a full tier before the contract
+    // tier. `0.saturating_sub(2) == 0` keeps ProductionUnit (unlock tier 0) in
+    // the tier-0 pool.
+    let beneficial_min_tokens = unlocked_token_types(tier.saturating_sub(2), effect_types);
+    for token in &beneficial_min_tokens {
         if token.is_beneficial() {
             let t = token.clone();
             let formula = formulas.output_threshold.clone();
@@ -362,8 +378,10 @@ fn available_requirement_generators(
         }
     }
 
-    // TokenRequirement generators for each harmful token that's unlocked
-    for token in &available_tokens {
+    // Harmful max requirements: full current-tier set — safe because the player
+    // only accumulates harmful tokens by playing cards that produce them.
+    let harmful_max_tokens = unlocked_token_types(tier, effect_types);
+    for token in &harmful_max_tokens {
         if token.is_harmful() {
             let t = token.clone();
             let formula = formulas.harmful_token_limit.clone();

--- a/src/docs/designer.rs
+++ b/src/docs/designer.rs
@@ -382,10 +382,22 @@ fn build_contract_failure() -> DesignerSection {
                     .to_string(),
             },
             ReferenceEntry {
+                name: "AbandonContract — Emergency Escape".to_string(),
+                description: "After min_turns_before_abandon turns (default: 5) on a contract, \
+                    the AbandonContract action becomes available. Using it immediately ends the \
+                    contract as a failure with reason 'Abandoned'. This is a last-resort mechanism \
+                    for players genuinely stuck (e.g., all playable cards banned by tag constraints). \
+                    Abandonment counts in total_contracts_failed AND has its own \
+                    total_contracts_abandoned counter in /metrics. The streak resets to zero. \
+                    min_turns_before_abandon is configurable in game_rules.json."
+                    .to_string(),
+            },
+            ReferenceEntry {
                 name: "ContractResolution".to_string(),
                 description: "The action response includes a contract_resolution field \
                     with resolution_type 'Completed' (with contract and reward) or 'Failed' \
-                    (with contract and failure reason including which requirement was violated)."
+                    (with contract and failure reason including which requirement was violated, \
+                    or failure_type 'Abandoned' with turns_played for abandonment)."
                     .to_string(),
             },
         ],
@@ -462,7 +474,9 @@ fn build_metrics_system() -> DesignerSection {
                 name: "Contract Metrics".to_string(),
                 description: "Total contracts completed and failed, broken down per tier \
                     with completion rates (completed / attempted). Tracks attempted, \
-                    completed, and failed counts per tier."
+                    completed, and failed counts per tier. total_contracts_abandoned is a \
+                    subset of total_contracts_failed — it counts contracts ended via \
+                    AbandonContract; all abandoned contracts are also counted as failed."
                     .to_string(),
             },
             ReferenceEntry {
@@ -513,7 +527,8 @@ fn build_configuration() -> DesignerSection {
                 name: "configurations/general/game_rules.json".to_string(),
                 description: "Contains general rules (starting_hand_size, \
                     starting_deck_size, contracts_per_tier_to_advance, \
-                    contract_market_size_per_tier, discard_production_unit_bonus), \
+                    contract_market_size_per_tier, discard_production_unit_bonus, \
+                    min_turns_before_abandon), \
                     contract formula parameters (output_threshold, harmful_token_limit \
                     scaling formulas), turn_window and card_tag_constraint formula configs \
                     with unlock_tier gating, and adaptive_balance parameters."

--- a/src/docs/hints.rs
+++ b/src/docs/hints.rs
@@ -51,6 +51,7 @@ fn build_hints() -> HintsGuide {
             "After a contract failure, the adaptive system eases difficulty — it's okay to fail occasionally.".to_string(),
             "Check adaptive_adjustments on offered contracts to see how the game is adapting to your style.".to_string(),
             "Diversify your strategies to keep adaptive pressure balanced — specialization gets punished over time.".to_string(),
+            "AbandonContract is an emergency escape available after 5 turns — it counts as a failure and breaks your streak. Use it only when genuinely stuck, not as a routine strategy.".to_string(),
         ],
         tiers: vec![
             build_tier0_hints(),

--- a/src/docs/tutorial.rs
+++ b/src/docs/tutorial.rs
@@ -85,6 +85,7 @@ fn build_tutorial() -> Tutorial {
                 tips: vec![
                     "Without an active contract, you'll see AcceptContract actions.".to_string(),
                     "With an active contract, you'll see PlayCard and DiscardCard actions.".to_string(),
+                    "After 5 turns on a contract, AbandonContract also appears as an emergency escape.".to_string(),
                 ],
             },
             TutorialStep {
@@ -196,6 +197,8 @@ fn build_tutorial() -> Tutorial {
                     "Failure is not game-over — it just means no reward and a broken streak.".to_string(),
                     "After failure, the adaptive system eases difficulty, giving you breathing room.".to_string(),
                     "The contract_turns_played field in /state shows how many turns you've used.".to_string(),
+                    "AbandonContract becomes available after 5 turns as a last resort — it counts as a failure.".to_string(),
+                    "Use AbandonContract only if truly stuck (e.g., all cards banned); it breaks your streak.".to_string(),
                 ],
             },
             TutorialStep {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -59,6 +59,12 @@ pub enum ActionSuccess {
     },
     /// A deck/discard card was replaced with a shelved card; sacrifice destroyed.
     CardReplaced,
+    /// The active contract was voluntarily abandoned after the required minimum turns.
+    ///
+    /// The `contract_resolution` is always a `Failed` resolution with reason `Abandoned`.
+    ContractAbandoned {
+        contract_resolution: ContractResolution,
+    },
 }
 
 /// Error outcomes — explicit variants for every failure mode.
@@ -114,6 +120,13 @@ pub enum ActionError {
     CardTagBanned {
         tag: CardTag,
     },
+    /// AbandonContract was attempted but the required minimum turns have not been played yet.
+    AbandonContractNotAllowed {
+        turns_played: u32,
+        turns_required: u32,
+    },
+    /// AbandonContract was attempted but there is no active contract.
+    NoContractToAbandon,
 }
 
 // ---------------------------------------------------------------------------
@@ -195,6 +208,9 @@ pub enum PossibleAction {
         valid_replacement_card_indices: Vec<usize>,
         valid_sacrifice_card_indices: Vec<usize>,
     },
+    /// Available when an active contract has been running for at least
+    /// `min_turns_before_abandon` turns. Abandoning counts as a failure.
+    AbandonContract,
 }
 
 // ---------------------------------------------------------------------------
@@ -435,6 +451,11 @@ impl GameState {
                     });
                 }
             }
+
+            // AbandonContract becomes available after the minimum turns threshold
+            if self.contract_turns_played >= self.rules.general.min_turns_before_abandon {
+                actions.push(PossibleAction::AbandonContract);
+            }
         } else {
             let valid_tiers: Vec<TierContractRange> = self
                 .offered_contracts
@@ -589,6 +610,7 @@ impl GameState {
                 replacement_card_index,
                 sacrifice_card_index,
             ),
+            PlayerAction::AbandonContract => self.handle_abandon_contract(),
         }
     }
 
@@ -851,6 +873,36 @@ impl GameState {
         self.metrics_tracker.record_card_replaced();
 
         ActionResult::Success(ActionSuccess::CardReplaced)
+    }
+
+    fn handle_abandon_contract(&mut self) -> ActionResult {
+        let contract = match self.active_contract.as_ref() {
+            Some(c) => c.clone(),
+            None => return ActionResult::Error(ActionError::NoContractToAbandon),
+        };
+
+        let turns_required = self.rules.general.min_turns_before_abandon;
+        if self.contract_turns_played < turns_required {
+            return ActionResult::Error(ActionError::AbandonContractNotAllowed {
+                turns_played: self.contract_turns_played,
+                turns_required,
+            });
+        }
+
+        let turns_played = self.contract_turns_played;
+        self.metrics_tracker
+            .record_contract_abandoned(contract.tier.0);
+        self.adaptive_tracker.on_contract_failed();
+        self.active_contract = None;
+        self.contract_turns_played = 0;
+        self.cards_played_per_tag_contract.clear();
+        self.refill_contract_market();
+
+        let reason = ContractFailureReason::Abandoned { turns_played };
+        let contract_resolution = ContractResolution::Failed { contract, reason };
+        ActionResult::Success(ActionSuccess::ContractAbandoned {
+            contract_resolution,
+        })
     }
 
     // -------------------------------------------------------------------

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,6 +23,8 @@ pub struct MetricsTracker {
     contracts_failed: u32,
     contracts_failed_per_tier: HashMap<u32, u32>,
     contracts_attempted_per_tier: HashMap<u32, u32>,
+    contracts_abandoned: u32,
+    contracts_abandoned_per_tier: HashMap<u32, u32>,
 
     // Card counters
     total_cards_played: u32,
@@ -53,6 +55,8 @@ impl MetricsTracker {
             contracts_failed: 0,
             contracts_failed_per_tier: HashMap::new(),
             contracts_attempted_per_tier: HashMap::new(),
+            contracts_abandoned: 0,
+            contracts_abandoned_per_tier: HashMap::new(),
             total_cards_played: 0,
             total_cards_discarded: 0,
             cards_played_per_tag: HashMap::new(),
@@ -120,6 +124,18 @@ impl MetricsTracker {
         self.current_streak = 0;
     }
 
+    /// Record a contract abandonment.
+    ///
+    /// Abandonment counts as a failure in all failure metrics (calls
+    /// `record_contract_failed` internally) and also increments its own
+    /// dedicated counter so callers can distinguish voluntary abandons from
+    /// mechanical failures.
+    pub fn record_contract_abandoned(&mut self, tier: u32) {
+        self.record_contract_failed(tier);
+        self.contracts_abandoned += 1;
+        *self.contracts_abandoned_per_tier.entry(tier).or_insert(0) += 1;
+    }
+
     pub fn record_card_replaced(&mut self) {
         self.total_cards_replaced += 1;
     }
@@ -142,6 +158,7 @@ impl MetricsTracker {
         SessionMetrics {
             total_contracts_completed: self.contracts_completed,
             total_contracts_failed: self.contracts_failed,
+            total_contracts_abandoned: self.contracts_abandoned,
             contracts_per_tier,
             total_cards_played: self.total_cards_played,
             total_cards_discarded: self.total_cards_discarded,
@@ -307,8 +324,11 @@ fn compute_strategy_analysis(tag_counts: &HashMap<CardTag, u32>) -> (Option<Stri
 pub struct SessionMetrics {
     /// Total contracts completed across all tiers.
     pub total_contracts_completed: u32,
-    /// Total contracts failed across all tiers.
+    /// Total contracts failed across all tiers (includes abandoned contracts).
     pub total_contracts_failed: u32,
+    /// Total contracts abandoned via `AbandonContract`.
+    /// These are a subset of `total_contracts_failed`.
+    pub total_contracts_abandoned: u32,
     /// Per-tier completion statistics.
     pub contracts_per_tier: Vec<TierCompletionMetrics>,
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -404,6 +404,11 @@ pub enum ContractFailureReason {
     },
     /// The contract's turn window expired.
     TurnWindowExceeded { max_turn: u32, current_turn: u32 },
+    /// The player voluntarily abandoned the contract.
+    ///
+    /// Only allowed after `min_turns_before_abandon` turns have been played.
+    /// Counts as a failure in all failure metrics.
+    Abandoned { turns_played: u32 },
 }
 
 /// A group of contract offers for a single tier.

--- a/tests/contract_failure_test.rs
+++ b/tests/contract_failure_test.rs
@@ -515,3 +515,278 @@ fn pressure_snapshot_sorted() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #13: AbandonContract action
+// ---------------------------------------------------------------------------
+
+fn get_possible_actions(client: &Client) -> serde_json::Value {
+    let response = client.get("/actions/possible").dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    let body = response.into_string().expect("response body");
+    serde_json::from_str(&body).expect("valid json")
+}
+
+fn has_possible_action(client: &Client, action_type: &str) -> bool {
+    let actions = get_possible_actions(client);
+    actions
+        .as_array()
+        .expect("array")
+        .iter()
+        .any(|a| a["action_type"] == action_type)
+}
+
+/// Play N turns on the active contract without checking for resolution.
+fn play_n_turns(client: &Client, n: u32) {
+    for _ in 0..n {
+        let state = get_state(client);
+        if state["active_contract"].is_null() {
+            return;
+        }
+        let idx = first_card_in_hand(client);
+        let (_, result) = post_action(
+            client,
+            &format!(r#"{{"action_type":"PlayCard","card_index":{idx}}}"#),
+        );
+        // If PlayCard fails (e.g. insufficient tokens), fall back to DiscardCard
+        if result["outcome"] == "Error" {
+            let idx = first_card_in_hand(client);
+            post_action(
+                client,
+                &format!(r#"{{"action_type":"DiscardCard","card_index":{idx}}}"#),
+            );
+        }
+    }
+}
+
+#[test]
+fn abandon_contract_not_available_before_min_turns() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    // After 0 turns, AbandonContract should not be available
+    assert!(
+        !has_possible_action(&client, "AbandonContract"),
+        "AbandonContract should not be available immediately after accepting"
+    );
+}
+
+#[test]
+fn abandon_contract_available_after_min_turns() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    // Play exactly min_turns_before_abandon turns (default: 5)
+    play_n_turns(&client, 5);
+
+    let state = get_state(&client);
+    if state["active_contract"].is_null() {
+        // Contract already resolved, skip test — just verify no panic occurred
+        return;
+    }
+
+    assert!(
+        has_possible_action(&client, "AbandonContract"),
+        "AbandonContract should be available after min_turns_before_abandon turns"
+    );
+}
+
+#[test]
+fn abandon_contract_error_when_not_enough_turns() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    // Attempt abandon at turn 0 — should get an error
+    let (status, result) = post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+    assert_eq!(status, Status::Ok);
+    assert_eq!(result["outcome"], "Error");
+    assert_eq!(
+        result["detail"]["error_type"], "AbandonContractNotAllowed",
+        "error should be AbandonContractNotAllowed"
+    );
+    let turns_played = result["detail"]["turns_played"].as_u64().unwrap_or(99);
+    let turns_required = result["detail"]["turns_required"].as_u64().unwrap_or(0);
+    assert!(
+        turns_played < turns_required,
+        "turns_played ({}) should be less than turns_required ({})",
+        turns_played,
+        turns_required
+    );
+}
+
+#[test]
+fn abandon_contract_no_active_contract_error() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    // No contract active — should get NoContractToAbandon error
+    let (status, result) = post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+    assert_eq!(status, Status::Ok);
+    assert_eq!(result["outcome"], "Error");
+    assert_eq!(result["detail"]["error_type"], "NoContractToAbandon");
+}
+
+#[test]
+fn abandon_contract_counts_as_failure_in_metrics() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    // Play 5 turns so abandon becomes available
+    play_n_turns(&client, 5);
+
+    let state = get_state(&client);
+    if state["active_contract"].is_null() {
+        // Contract resolved before we could abandon; skip.
+        return;
+    }
+
+    let (status, result) = post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+    assert_eq!(status, Status::Ok);
+    assert_eq!(result["outcome"], "Success");
+    assert_eq!(result["detail"]["result_type"], "ContractAbandoned");
+
+    let resolution = &result["detail"]["contract_resolution"];
+    assert_eq!(resolution["resolution_type"], "Failed");
+    assert_eq!(resolution["reason"]["failure_type"], "Abandoned");
+    let turns_played = resolution["reason"]["turns_played"].as_u64().unwrap_or(0);
+    assert!(
+        turns_played >= 5,
+        "abandoned turns_played should be >= min_turns_before_abandon"
+    );
+
+    let metrics = get_metrics(&client);
+    assert_eq!(
+        metrics["total_contracts_failed"].as_u64().unwrap_or(0),
+        1,
+        "total_contracts_failed should be 1 after abandonment"
+    );
+    assert_eq!(
+        metrics["total_contracts_abandoned"].as_u64().unwrap_or(0),
+        1,
+        "total_contracts_abandoned should be 1"
+    );
+}
+
+#[test]
+fn abandon_contract_resets_contract_state() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+
+    play_n_turns(&client, 5);
+
+    let state = get_state(&client);
+    if state["active_contract"].is_null() {
+        return; // Contract resolved naturally; skip test.
+    }
+
+    post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+
+    let state_after = get_state(&client);
+    assert!(
+        state_after["active_contract"].is_null(),
+        "active_contract should be cleared after abandonment"
+    );
+    assert_eq!(
+        state_after["contract_turns_played"].as_u64().unwrap_or(99),
+        0,
+        "contract_turns_played should reset to 0 after abandonment"
+    );
+}
+
+#[test]
+fn abandon_contract_breaks_streak() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    // Complete one contract to build a streak
+    complete_one_contract(&client);
+    let metrics_before = get_metrics(&client);
+    let streak_before = metrics_before["current_streak"].as_u64().unwrap_or(0);
+    assert!(
+        streak_before >= 1,
+        "streak should be >= 1 after a completion"
+    );
+
+    // Accept another contract and abandon it
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+    play_n_turns(&client, 5);
+
+    let state = get_state(&client);
+    if state["active_contract"].is_null() {
+        return; // Resolved naturally.
+    }
+
+    post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+
+    let metrics_after = get_metrics(&client);
+    assert_eq!(
+        metrics_after["current_streak"].as_u64().unwrap_or(99),
+        0,
+        "current_streak should reset to 0 after abandonment"
+    );
+}
+
+#[test]
+fn abandon_contract_refills_market() {
+    let client = client();
+    post_action(&client, r#"{"action_type":"NewGame","seed":42}"#);
+
+    let state_before = get_state(&client);
+    let contracts_before: usize = state_before["offered_contracts"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|tc| tc["contracts"].as_array().map(|a| a.len()).unwrap_or(0))
+        .sum();
+
+    post_action(
+        &client,
+        r#"{"action_type":"AcceptContract","tier_index":0,"contract_index":0}"#,
+    );
+    play_n_turns(&client, 5);
+
+    let state = get_state(&client);
+    if state["active_contract"].is_null() {
+        return;
+    }
+
+    post_action(&client, r#"{"action_type":"AbandonContract"}"#);
+
+    let state_after = get_state(&client);
+    let contracts_after: usize = state_after["offered_contracts"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|tc| tc["contracts"].as_array().map(|a| a.len()).unwrap_or(0))
+        .sum();
+
+    assert!(
+        contracts_after >= contracts_before,
+        "market should refill after abandonment (before={}, after={})",
+        contracts_before,
+        contracts_after
+    );
+}

--- a/tests/simulation/game_driver.rs
+++ b/tests/simulation/game_driver.rs
@@ -32,6 +32,7 @@ pub struct GameResult {
     pub total_actions: u64,
     pub contracts_completed: u32,
     pub contracts_failed: u32,
+    pub contracts_abandoned: u32,
     /// Count of each contract failure reason observed.
     pub failure_reasons: HashMap<String, u32>,
     /// True when max_actions was exhausted before all milestones were reached.
@@ -49,6 +50,7 @@ impl GameResult {
             total_actions: 0,
             contracts_completed: 0,
             contracts_failed: 0,
+            contracts_abandoned: 0,
             failure_reasons: HashMap::new(),
             hit_action_limit: false,
             stuck: false,
@@ -133,6 +135,9 @@ impl GameDriver {
                             .as_str()
                             .unwrap_or("Unknown")
                             .to_string();
+                        if failure_type == "Abandoned" {
+                            result.contracts_abandoned += 1;
+                        }
                         *result.failure_reasons.entry(failure_type).or_insert(0) += 1;
                     }
                     _ => {}

--- a/tests/simulation/runner.rs
+++ b/tests/simulation/runner.rs
@@ -46,6 +46,7 @@ pub struct StrategyReport {
     pub overall_max_tier: Option<u32>,
     pub total_contracts_completed: u64,
     pub total_contracts_failed: u64,
+    pub total_contracts_abandoned: u64,
     /// Top contract failure reasons sorted by frequency (descending).
     pub top_failure_reasons: Vec<(String, u64)>,
     pub stuck_games: u32,
@@ -81,10 +82,11 @@ impl SimulationRunner {
             );
             let result = driver.play_game(seed, strategy);
             eprintln!(
-                "  max_tier={:?} completed={} failed={} actions={}{}",
+                "  max_tier={:?} completed={} failed={} abandoned={} actions={}{}",
                 result.max_tier_reached,
                 result.contracts_completed,
                 result.contracts_failed,
+                result.contracts_abandoned,
                 result.total_actions,
                 if result.hit_action_limit {
                     " [LIMIT]"
@@ -137,6 +139,10 @@ impl SimulationRunner {
             .sum();
         let total_contracts_failed: u64 =
             results.iter().map(|r| u64::from(r.contracts_failed)).sum();
+        let total_contracts_abandoned: u64 = results
+            .iter()
+            .map(|r| u64::from(r.contracts_abandoned))
+            .sum();
 
         let mut failure_totals: HashMap<String, u64> = HashMap::new();
         for result in &results {
@@ -157,6 +163,7 @@ impl SimulationRunner {
             overall_max_tier,
             total_contracts_completed,
             total_contracts_failed,
+            total_contracts_abandoned,
             top_failure_reasons,
             stuck_games,
             action_limit_games,

--- a/tests/simulation/strategies/simple_first.rs
+++ b/tests/simulation/strategies/simple_first.rs
@@ -7,6 +7,9 @@ use crate::strategies::Strategy;
 /// - Accepts the highest available tier contract (last in valid_tiers list)
 /// - Always plays the first valid card
 /// - Discards only when no card can be played
+/// - Abandons the contract as last resort (after min_turns_before_abandon) when
+///   neither PlayCard nor DiscardCard is possible — this prevents permanent stalls
+///   on uncompletable contracts
 /// - Never deckbuilds (ignores ReplaceCard)
 ///
 /// Picking the highest tier ensures the strategy actually attempts to advance
@@ -77,6 +80,16 @@ impl Strategy for SimpleFirstStrategy {
                     });
                 }
             }
+        }
+
+        // 3.5. Abandon the contract as a last resort when stuck — no PlayCard or
+        //      DiscardCard available (e.g. all cards banned by a CardTagConstraint
+        //      and hand is empty after exhausting the deck).
+        if possible_actions
+            .iter()
+            .any(|a| a["action_type"] == "AbandonContract")
+        {
+            return json!({ "action_type": "AbandonContract" });
         }
 
         panic!(

--- a/tests/tier_progression_test.rs
+++ b/tests/tier_progression_test.rs
@@ -2,7 +2,8 @@
 //!
 //! Validates the combinatorial effect type generator, proportional model,
 //! HarmfulTokenLimit requirements, requirement tier-gating, duplicate
-//! requirement stacking, and direction_sign correctness.
+//! requirement stacking, direction_sign correctness, and the Issue #14
+//! beneficial-token-min one-tier delay invariant.
 
 use my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker;
 use my_little_factory_manager::config_loader::{load_game_rules, load_token_definitions};
@@ -738,4 +739,191 @@ fn contracts_valid_across_many_tiers_and_seeds() {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #14: beneficial-token min requirement one-tier delay invariant
+// ---------------------------------------------------------------------------
+
+/// For every non-ProductionUnit beneficial token, the token must NOT appear as
+/// a `TokenRequirement { min: Some(_) }` in contracts generated at the exact
+/// req_tier where that token's producer card-effect first unlocks.  It should
+/// only start appearing one tier later.
+///
+/// ProductionUnit is exempt: it unlocks at tier 0 and `0.saturating_sub(1) == 0`,
+/// so tier 0 beneficial-min pool still includes it.
+#[test]
+fn beneficial_min_requirement_absent_at_token_producer_unlock_tier() {
+    let token_defs = load_token_definitions().expect("config");
+    let effect_types = generate_effect_types(&token_defs);
+    let game_rules = load_game_rules().expect("game rules");
+    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
+        game_rules.adaptive_balance.clone(),
+    );
+
+    // Find (token, producer_unlock_tier) for each non-PU beneficial token.
+    let beneficial_tokens: Vec<(TokenType, u32)> = {
+        let mut seen = std::collections::HashMap::new();
+        for et in &effect_types {
+            if et.primary_token.is_beneficial()
+                && et.primary_token != TokenType::ProductionUnit
+                && matches!(et.main_direction, MainEffectDirection::Producer)
+            {
+                seen.entry(et.primary_token.clone())
+                    .or_insert(et.available_at_tier);
+            }
+        }
+        seen.into_iter().collect()
+    };
+
+    assert!(
+        !beneficial_tokens.is_empty(),
+        "should have at least one non-PU beneficial token with a producer"
+    );
+
+    for (token, unlock_tier) in &beneficial_tokens {
+        // Generate 200 contracts at exactly the unlock tier; none should have a
+        // beneficial-min requirement for this token.
+        for seed in 0u64..200 {
+            let mut rng = Pcg64::seed_from_u64(seed);
+            let contract = generate_contract_with_types(
+                ContractTier(*unlock_tier),
+                &mut rng,
+                &game_rules.contract_formulas,
+                &token_defs,
+                &effect_types,
+                &adaptive,
+            );
+
+            for req in &contract.requirements {
+                if let ContractRequirementKind::TokenRequirement {
+                    token_type,
+                    min: Some(_),
+                    ..
+                } = req
+                {
+                    assert_ne!(
+                        token_type, token,
+                        "token {:?} (unlocks at tier {}) must NOT appear as a beneficial-min \
+                         requirement in contracts at req_tier {} (seed {})",
+                        token, unlock_tier, unlock_tier, seed
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// At req_tier = unlock_tier + 1, the token's beneficial-min pool now includes it
+/// (since we use `tier.saturating_sub(1) = unlock_tier`).  Over 200 seeds, the
+/// token must appear at least once so the feature is also reachable.
+#[test]
+fn beneficial_min_requirement_reachable_one_tier_after_unlock() {
+    let token_defs = load_token_definitions().expect("config");
+    let effect_types = generate_effect_types(&token_defs);
+    let game_rules = load_game_rules().expect("game rules");
+    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
+        game_rules.adaptive_balance.clone(),
+    );
+
+    let beneficial_tokens: Vec<(TokenType, u32)> = {
+        let mut seen = std::collections::HashMap::new();
+        for et in &effect_types {
+            if et.primary_token.is_beneficial()
+                && et.primary_token != TokenType::ProductionUnit
+                && matches!(et.main_direction, MainEffectDirection::Producer)
+            {
+                seen.entry(et.primary_token.clone())
+                    .or_insert(et.available_at_tier);
+            }
+        }
+        seen.into_iter().collect()
+    };
+
+    for (token, unlock_tier) in &beneficial_tokens {
+        let req_tier = unlock_tier + 1;
+        let mut found = false;
+
+        for seed in 0u64..200 {
+            let mut rng = Pcg64::seed_from_u64(seed);
+            let contract = generate_contract_with_types(
+                ContractTier(req_tier),
+                &mut rng,
+                &game_rules.contract_formulas,
+                &token_defs,
+                &effect_types,
+                &adaptive,
+            );
+
+            for req in &contract.requirements {
+                if let ContractRequirementKind::TokenRequirement {
+                    token_type,
+                    min: Some(_),
+                    ..
+                } = req
+                {
+                    if token_type == token {
+                        found = true;
+                    }
+                }
+            }
+
+            if found {
+                break;
+            }
+        }
+
+        assert!(
+            found,
+            "token {:?} (unlocks at tier {}) should appear as a beneficial-min \
+             requirement in at least one contract at req_tier {} (over 200 seeds)",
+            token, unlock_tier, req_tier
+        );
+    }
+}
+
+/// ProductionUnit unlocks at tier 0.  Because `0.saturating_sub(2) == 0`, it
+/// should still be reachable as a beneficial-min requirement in tier-0 contracts.
+#[test]
+fn production_unit_min_requirement_reachable_at_tier_0() {
+    let token_defs = load_token_definitions().expect("config");
+    let effect_types = generate_effect_types(&token_defs);
+    let game_rules = load_game_rules().expect("game rules");
+    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
+        game_rules.adaptive_balance.clone(),
+    );
+
+    let mut found = false;
+    for seed in 0u64..500 {
+        let mut rng = Pcg64::seed_from_u64(seed);
+        let contract = generate_contract_with_types(
+            ContractTier(0),
+            &mut rng,
+            &game_rules.contract_formulas,
+            &token_defs,
+            &effect_types,
+            &adaptive,
+        );
+
+        for req in &contract.requirements {
+            if let ContractRequirementKind::TokenRequirement {
+                token_type: TokenType::ProductionUnit,
+                min: Some(_),
+                ..
+            } = req
+            {
+                found = true;
+            }
+        }
+
+        if found {
+            break;
+        }
+    }
+
+    assert!(
+        found,
+        "ProductionUnit should still appear as a min requirement in tier-0 contracts \
+         (saturating_sub(2) == 0 preserves tier-0 inclusion)"
+    );
 }

--- a/tests/types_serialization_test.rs
+++ b/tests/types_serialization_test.rs
@@ -390,7 +390,8 @@ fn load_custom_game_rules_json() {
             "starting_deck_size": 15,
             "contracts_per_tier_to_advance": 5,
             "contract_market_size_per_tier": 4,
-            "discard_production_unit_bonus": 2
+            "discard_production_unit_bonus": 2,
+            "min_turns_before_abandon": 8
         },
         "contract_formulas": {
             "output_threshold": {
@@ -421,6 +422,7 @@ fn load_custom_game_rules_json() {
     assert_eq!(config.general.contracts_per_tier_to_advance, 5);
     assert_eq!(config.general.contract_market_size_per_tier, 4);
     assert_eq!(config.general.discard_production_unit_bonus, 2);
+    assert_eq!(config.general.min_turns_before_abandon, 8);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements issues [#13](https://github.com/RobbingDaHood/my_little_factory_manager/issues/13) and [#14](https://github.com/RobbingDaHood/my_little_factory_manager/issues/14), then re-runs the Phase 10.1 simulation.

---

## Issue #13 — AbandonContract emergency escape

After `min_turns_before_abandon` turns (default: **5**) on a contract, a new `AbandonContract` action becomes available. This gives players a guaranteed exit from contracts they cannot complete (e.g., all cards banned by tag constraints).

- Counts as a **failure**: breaks streak, increments `total_contracts_failed`
- Has its own **separate counter**: `total_contracts_abandoned` in `/metrics`
- `min_turns_before_abandon` is configurable in `game_rules.json`

New code:
- `PlayerAction::AbandonContract` in `action_log.rs`
- `ContractFailureReason::Abandoned { turns_played }` in `types.rs`
- `ActionSuccess::ContractAbandoned`, `ActionError::AbandonContractNotAllowed`, `ActionError::NoContractToAbandon`, `PossibleAction::AbandonContract` in `game_state.rs`
- `handle_abandon_contract()` in `game_state.rs`
- `contracts_abandoned`, `record_contract_abandoned()`, `total_contracts_abandoned` in `metrics.rs`
- 8 new integration tests in `tests/contract_failure_test.rs`

---

## Issue #14 — Beneficial token min requirement tier-gating

Beneficial-token `min` requirements now use `unlocked_token_types(tier.saturating_sub(2), ...)` instead of the full current-tier set. This ensures a token that first unlocks at tier T only appears as a min requirement starting from contract tier T+1.

**Why `saturating_sub(2)` not `saturating_sub(1)`**: `roll_requirement_tier` can return `contract_tier + 1`, so with `sub(1)` a token at T would still appear via `req_tier = T+1`. With `sub(2)`, tokens enter the pool only at `req_tier >= T+2`, which is only reachable in contracts at `contract_tier >= T+1`. `0.saturating_sub(2) == 0` preserves ProductionUnit in tier-0 contracts.

3 new tests in `tests/tier_progression_test.rs` verify the invariant.

---

## Phase 10.1 Simulation Re-run Results

```
Strategy:  simple_first
Seeds:     3 (42, 43, 44)
Max tier:  5  (up from 3)
Completed: 52–54 contracts per game
Failures:  0
Abandoned: 0
Actions:   2,000,000 (limit hit all 3 games)
```

**Key findings:**
- **Tier 3 → Tier 5**: The tier-gating fix (Issue #14) eliminated the stuck-on-uncompletable-contract problem. The strategy now reliably reaches tier 5 with zero failures.
- **AbandonContract was never needed**: Zero abandonments confirm the simple strategy is never truly stuck — it can always discard to make progress.
- **Bottleneck is efficiency, not correctness**: At tier 5, each contract takes ~38K actions (many deck shuffles to accumulate enough PUs). The strategy hits the 2M action limit before reaching the 10 tier-5 completions needed to unlock tier 6.

---

## Suggested Improvements (for Phase 10.2+)

1. **PU-first card selection**: A strategy that plays PU-producing cards preferentially over other cards would dramatically reduce actions-per-contract at higher tiers. This should be the first Phase 10.2 strategy.
2. **Contract-aware selection**: Read the active contract's token requirements and prefer cards that contribute toward them (e.g., prefer Energy cards when the contract requires Energy output).
3. **Harmful token avoidance**: Track current harmful token levels vs. contract limits; discard instead of playing cards that would push past a max limit.
4. **Deckbuilding**: Use ReplaceCard rewards to build a stronger deck over time. A strategy that improves deck composition would compound gains across contracts.
5. **Abandonment as balance signal**: The Phase 10.5 balancing target now includes an abandonment rate requirement — strategies that abandon frequently must perform measurably worse than those that complete contracts.