### PR TITLE
BREAKING: replace CardTag enum with input/output token signature struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The game also provides self-documenting endpoints:
 #### Library
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /library/cards` | Card catalogue with optional `?tag=` filter |
+| `GET /library/cards` | Card catalogue with optional `?tag=` filter (JSON object: `{"input":[],"output":["ProductionUnit"]}`, URL-encoded) |
 
 #### Statistics
 | Endpoint | Purpose |

--- a/configurations/card_effects/token_definitions.json
+++ b/configurations/card_effects/token_definitions.json
@@ -3,51 +3,37 @@
         {
             "token_type": "ProductionUnit",
             "is_beneficial": true,
-            "primary_formula": { "base_min": 1, "base_max": 5, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["Transformation"]
+            "primary_formula": { "base_min": 1, "base_max": 5, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "Heat",
             "is_beneficial": false,
-            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["QualityControl"]
+            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "Energy",
             "is_beneficial": true,
-            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["Transformation"]
+            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "Waste",
             "is_beneficial": false,
-            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["QualityControl"]
+            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "QualityPoint",
             "is_beneficial": true,
-            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["Transformation"]
+            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "Pollution",
             "is_beneficial": false,
-            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["QualityControl"]
+            "primary_formula": { "base_min": 1, "base_max": 3, "per_tier_min": 1, "per_tier_max": 2 }
         },
         {
             "token_type": "Innovation",
             "is_beneficial": true,
-            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 },
-            "producer_tags": ["Production"],
-            "consumer_tags": ["Transformation"]
+            "primary_formula": { "base_min": 1, "base_max": 4, "per_tier_min": 1, "per_tier_max": 2 }
         }
     ],
     "variation_defaults": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,15 +144,13 @@ pub struct TokenDefinitionsConfig {
     pub variation_defaults: VariationDefaultsConfig,
 }
 
-/// One token's definition: type, classification, primary formula, and tags.
+/// One token's definition: type, classification, and primary formula.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(crate = "rocket::serde")]
 pub struct TokenDefinitionConfig {
     pub token_type: TokenType,
     pub is_beneficial: bool,
     pub primary_formula: TierScalingFormula,
-    pub producer_tags: Vec<CardTag>,
-    pub consumer_tags: Vec<CardTag>,
 }
 
 /// Global defaults for variation generation.
@@ -175,7 +173,8 @@ pub struct VariationDefaultsConfig {
 #[derive(Debug, Clone)]
 pub struct CardEffectTypeConfig {
     pub name: String,
-    pub tags: Vec<CardTag>,
+    /// Base input/output token signature for this effect type (no variation selected).
+    pub tag: CardTag,
     pub available_at_tier: u32,
     pub primary_token: TokenType,
     pub main_direction: MainEffectDirection,

--- a/src/contract_generation.rs
+++ b/src/contract_generation.rs
@@ -23,6 +23,7 @@ use crate::types::{
     CardEffect, CardTag, Contract, ContractRequirementKind, ContractTier, MainEffectDirection,
     PlayerActionCard, TokenAmount, TokenType, VariationDirection,
 };
+use std::collections::BTreeSet;
 
 type RequirementGenerator = Box<dyn Fn(&mut Pcg64) -> ContractRequirementKind>;
 
@@ -76,7 +77,6 @@ pub fn generate_effect_types(config: &TokenDefinitionsConfig) -> Vec<CardEffectT
         let producer_name = format!("{:?}Producer", token_def.token_type);
         all_items.push(GeneratedItem::Main {
             name: producer_name,
-            tags: token_def.producer_tags.clone(),
             primary_token: token_def.token_type.clone(),
             direction: MainEffectDirection::Producer,
             formula: token_def.primary_formula.clone(),
@@ -91,7 +91,6 @@ pub fn generate_effect_types(config: &TokenDefinitionsConfig) -> Vec<CardEffectT
             };
             all_items.push(GeneratedItem::Main {
                 name: consumer_name,
-                tags: token_def.consumer_tags.clone(),
                 primary_token: token_def.token_type.clone(),
                 direction: MainEffectDirection::Consumer,
                 formula: token_def.primary_formula.clone(),
@@ -166,14 +165,23 @@ pub fn generate_effect_types(config: &TokenDefinitionsConfig) -> Vec<CardEffectT
         match item {
             GeneratedItem::Main {
                 name,
-                tags,
                 primary_token,
                 direction,
                 formula,
             } => {
+                let tag = match direction {
+                    MainEffectDirection::Producer => CardTag {
+                        input: BTreeSet::new(),
+                        output: BTreeSet::from([primary_token.clone()]),
+                    },
+                    MainEffectDirection::Consumer => CardTag {
+                        input: BTreeSet::from([primary_token.clone()]),
+                        output: BTreeSet::new(),
+                    },
+                };
                 effect_types.push(CardEffectTypeConfig {
                     name: name.clone(),
-                    tags: tags.clone(),
+                    tag,
                     available_at_tier: current_tier,
                     primary_token: primary_token.clone(),
                     main_direction: direction.clone(),
@@ -285,7 +293,6 @@ fn attach_variation(
 enum GeneratedItem {
     Main {
         name: String,
-        tags: Vec<CardTag>,
         primary_token: TokenType,
         direction: MainEffectDirection,
         formula: TierScalingFormula,
@@ -321,15 +328,33 @@ fn unlocked_token_types(tier: u32, effect_types: &[CardEffectTypeConfig]) -> Vec
     tokens
 }
 
-/// Returns card tags associated with effect types unlocked at or before the given tier.
-/// Used to ensure CardTagConstraint only references tags that have actual cards.
+/// Returns all distinct card tags that can appear on generated cards at or before the given tier.
+///
+/// Enumerates the base tag for each unlocked effect type, plus one tag per unlocked variation
+/// (base tag extended with the variation's secondary token). This mirrors exactly the tag space
+/// that `generate_reward_card_with_types` can produce, ensuring `CardTagConstraint` requirements
+/// only reference tag profiles that real cards can carry.
 fn unlocked_card_tags(tier: u32, effect_types: &[CardEffectTypeConfig]) -> Vec<CardTag> {
     let mut tags = Vec::new();
     for et in effect_types {
         if et.available_at_tier <= tier {
-            for tag in &et.tags {
-                if !tags.contains(tag) {
-                    tags.push(tag.clone());
+            if !tags.contains(&et.tag) {
+                tags.push(et.tag.clone());
+            }
+            for var in &et.variations {
+                if var.unlock_tier <= tier {
+                    let mut var_tag = et.tag.clone();
+                    match var.direction {
+                        VariationDirection::Input => {
+                            var_tag.input.insert(var.secondary_token.clone());
+                        }
+                        VariationDirection::Output => {
+                            var_tag.output.insert(var.secondary_token.clone());
+                        }
+                    }
+                    if !tags.contains(&var_tag) {
+                        tags.push(var_tag);
+                    }
                 }
             }
         }
@@ -618,10 +643,19 @@ pub fn generate_reward_card_with_types(
         .map(|_| {
             let selected = weighted_select(&choices, rng);
 
-            for tag in &selected.root.tags {
-                if !all_tags.contains(tag) {
-                    all_tags.push(tag.clone());
+            let mut tag = selected.root.tag.clone();
+            if let Some(v) = selected.variation {
+                match v.direction {
+                    VariationDirection::Input => {
+                        tag.input.insert(v.secondary_token.clone());
+                    }
+                    VariationDirection::Output => {
+                        tag.output.insert(v.secondary_token.clone());
+                    }
                 }
+            }
+            if !all_tags.contains(&tag) {
+                all_tags.push(tag);
             }
 
             match selected.variation {
@@ -636,10 +670,6 @@ pub fn generate_reward_card_with_types(
             }
         })
         .collect();
-
-    if all_tags.is_empty() {
-        all_tags.push(CardTag::Production);
-    }
 
     PlayerActionCard {
         tags: all_tags,

--- a/src/docs/designer.rs
+++ b/src/docs/designer.rs
@@ -482,8 +482,8 @@ fn build_metrics_system() -> DesignerSection {
             ReferenceEntry {
                 name: "Card Usage".to_string(),
                 description: "Total cards played and discarded, with per-tag breakdown. \
-                    Tracks how often Production, Transformation, QualityControl, and \
-                    SystemAdjustment tagged cards are used."
+                    Each tag is a precise input/output token signature \
+                    ({\"input\":[...],\"output\":[...]}) rather than a coarse category."
                     .to_string(),
             },
             ReferenceEntry {
@@ -507,9 +507,10 @@ fn build_metrics_system() -> DesignerSection {
             },
             ReferenceEntry {
                 name: "Strategy Diversity".to_string(),
-                description: "Dominant strategy tag and a normalized Shannon entropy \
-                    diversity score (0.0 = single tag only, 1.0 = perfectly even). \
-                    Measures how varied the player's card usage is."
+                description: "Dominant strategy tag (as a JSON input/output signature) \
+                    and a normalized Shannon entropy diversity score (0.0 = single tag \
+                    only, 1.0 = perfectly even). Measures how varied the player's \
+                    card usage is across distinct token-effect profiles."
                     .to_string(),
             },
         ],
@@ -536,10 +537,12 @@ fn build_configuration() -> DesignerSection {
             },
             ReferenceEntry {
                 name: "configurations/card_effects/token_definitions.json".to_string(),
-                description: "Defines the 7 game tokens with their primary formulas, tags, \
-                    and classification (beneficial/harmful). The combinatorial generator \
+                description: "Defines the 7 game tokens with their primary formulas \
+                    and classification (beneficial/harmful). Tags are no longer stored \
+                    in this file — they are auto-derived from each effect type's \
+                    primary_token and direction. The combinatorial generator \
                     auto-produces all card effect types (13 mains + 85 variations = 98 items) \
-                    from these ~5 parameters per token, plus global variation defaults \
+                    from these parameters per token, plus global variation defaults \
                     (ratio_range, efficiency_per_tier, boost_factor, items_per_tier). \
                     2 items are unlocked per tier, spanning tiers 0–48."
                     .to_string(),

--- a/src/docs/hints.rs
+++ b/src/docs/hints.rs
@@ -237,9 +237,10 @@ fn build_tier12_hints() -> TierHints {
             },
             Strategy {
                 name: "Build a balanced deck across tags".to_string(),
-                description: "If your deck is all Production cards, a contract banning \
-                    Production will be nearly impossible. Diversify your deck across \
-                    Production, Transformation, and QualityControl to handle any ban."
+                description: "Tags are now precise input/output token signatures. A ban on \
+                    cards that output Heat is far narrower than the old Production ban. \
+                    Diversify your deck so no single token type dominates both your inputs \
+                    and outputs — this keeps you flexible against any tag constraint."
                     .to_string(),
             },
             Strategy {

--- a/src/docs/tutorial.rs
+++ b/src/docs/tutorial.rs
@@ -253,7 +253,7 @@ fn build_tutorial() -> Tutorial {
                 method: "GET".to_string(),
                 example_body: None,
                 tips: vec![
-                    "Use ?tag=Production to see only production cards.".to_string(),
+                    r#"Filter by tag using a JSON object: ?tag={"input":[],"output":["ProductionUnit"]} (URL-encoded in practice)."#.to_string(),
                     "Card counts show how many copies are in each location.".to_string(),
                     "shelved = copies on the shelf; deck+hand+discard = copies in the active cycle.".to_string(),
                 ],

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -69,8 +69,9 @@ pub fn get_contracts_available(game_state: &State<Mutex<GameState>>) -> Json<Vec
 ///
 /// Returns all player action cards in the game with their per-location copy
 /// counts (shelved, deck, hand, discard). Use the optional `?tag=` query
-/// parameter to filter by card tag (e.g., `Production`, `Transformation`,
-/// `QualityControl`, `SystemAdjustment`).
+/// parameter to filter by card tag. Tags are JSON objects with `input` and
+/// `output` arrays of token type names, e.g.
+/// `?tag={"input":[],"output":["ProductionUnit"]}`.
 #[openapi]
 #[get("/library/cards?<tag>")]
 pub fn get_library_cards(
@@ -80,7 +81,7 @@ pub fn get_library_cards(
     let gs = game_state.lock().expect("game state lock poisoned");
 
     let tag_filter = match tag {
-        Some(t) => match serde_json::from_value::<CardTag>(serde_json::Value::String(t)) {
+        Some(t) => match serde_json::from_str::<CardTag>(&t) {
             Ok(parsed) => Some(parsed),
             Err(_) => return Json(Vec::new()),
         },

--- a/src/starter_cards.rs
+++ b/src/starter_cards.rs
@@ -36,7 +36,7 @@ pub fn create_starter_deck(count: u32, rng: &mut Pcg64) -> Vec<CardEntry> {
         let effect = roll_base_effect(0, selected, rng);
 
         let card = PlayerActionCard {
-            tags: selected.tags.clone(),
+            tags: vec![selected.tag.clone()],
             effects: vec![effect],
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 //! Core game types: tokens, cards, effects, contracts, and locations.
 
+use std::collections::BTreeSet;
+
 use rocket::serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
 
@@ -120,21 +122,21 @@ pub enum VariationDirection {
 // Card system
 // ---------------------------------------------------------------------------
 
-/// Operational category tags for player action cards.
+/// Precise input/output token signature for a player action card effect.
 ///
-/// A card can have multiple tags indicating what kind of factory operation
-/// it represents.
+/// Each card effect carries one tag describing exactly which token types it
+/// consumes (`input`) and which it produces (`output`). Tags are derived
+/// automatically from the card-effect template and any selected variation,
+/// so two cards with different token signatures always carry different tags.
+/// Used by `CardTagConstraint` requirements to target specific effect profiles
+/// rather than broad operational categories.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(crate = "rocket::serde")]
-pub enum CardTag {
-    /// Cards that generate output tokens.
-    Production,
-    /// Cards that convert one token type into another.
-    Transformation,
-    /// Cards that manage waste and harmful byproducts.
-    QualityControl,
-    /// Utility and meta-operational cards.
-    SystemAdjustment,
+pub struct CardTag {
+    /// Token types consumed when this effect is played.
+    pub input: BTreeSet<TokenType>,
+    /// Token types produced when this effect is played.
+    pub output: BTreeSet<TokenType>,
 }
 
 /// A card effect with token inputs consumed and token outputs produced.

--- a/tests/api_endpoints_test.rs
+++ b/tests/api_endpoints_test.rs
@@ -60,19 +60,30 @@ fn library_cards_returns_all_cards() {
 #[test]
 fn library_cards_filter_by_production_tag() {
     let client = create_client();
-    let response = client.get("/library/cards?tag=Production").dispatch();
+    // Tags are now JSON objects: {"input":[],"output":["ProductionUnit"]}
+    // URL-encoded to avoid invalid URI characters in the test client
+    let response = client
+        .get("/library/cards?tag=%7B%22input%22%3A%5B%5D%2C%22output%22%3A%5B%22ProductionUnit%22%5D%7D")
+        .dispatch();
     assert_eq!(response.status(), Status::Ok);
 
     let body: serde_json::Value =
         serde_json::from_str(&response.into_string().expect("body")).expect("valid json");
     let cards = body.as_array().expect("array");
-    assert!(cards.len() >= 3, "all starter cards are Production tagged");
+    assert!(
+        cards.len() >= 3,
+        "all starter cards are ProductionUnit producers"
+    );
 
     for card in cards {
         let tags = card["card"]["tags"].as_array().expect("tags array");
         assert!(
-            tags.iter().any(|t| t.as_str() == Some("Production")),
-            "filtered cards must have Production tag"
+            tags.iter().any(|t| {
+                t["output"]
+                    .as_array()
+                    .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("ProductionUnit")))
+            }),
+            "filtered cards must have ProductionUnit in their tag output"
         );
     }
 }

--- a/tests/deckbuilding_test.rs
+++ b/tests/deckbuilding_test.rs
@@ -485,16 +485,23 @@ fn tier1_reward_cards_are_pure_production() {
     let state = get_state(&client);
     let cards = state["cards"].as_array().expect("cards array");
 
-    // Reward cards should only have Production tags at tier 0
+    // Reward cards at tier 0 should only involve ProductionUnit tokens
     for card_entry in cards {
         let tags = card_entry["card"]["tags"].as_array();
         if let Some(tags) = tags {
             for tag in tags {
-                assert_eq!(
-                    tag.as_str().unwrap_or(""),
-                    "Production",
-                    "tier 0 reward cards should only have Production tags"
-                );
+                let input_tokens = tag["input"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
+                let output_tokens = tag["output"]
+                    .as_array()
+                    .map(|a| a.as_slice())
+                    .unwrap_or(&[]);
+                for token in input_tokens.iter().chain(output_tokens.iter()) {
+                    assert_eq!(
+                        token.as_str().unwrap_or(""),
+                        "ProductionUnit",
+                        "tier 0 reward card tags should only reference ProductionUnit"
+                    );
+                }
             }
         }
     }

--- a/tests/metrics_test.rs
+++ b/tests/metrics_test.rs
@@ -210,9 +210,17 @@ fn metrics_track_per_tag_counts() {
         .expect("cards_per_tag array");
     assert!(!tags.is_empty(), "should have at least one tag count");
 
-    // Verify tag entries have expected structure
+    // Verify tag entries have expected structure (tag is now a JSON object with input/output arrays)
     for tag_entry in tags {
-        assert!(tag_entry["tag"].is_string());
+        assert!(tag_entry["tag"].is_object(), "tag should be a JSON object");
+        assert!(
+            tag_entry["tag"]["input"].is_array(),
+            "tag.input should be an array"
+        );
+        assert!(
+            tag_entry["tag"]["output"].is_array(),
+            "tag.output should be an array"
+        );
         assert!(tag_entry["count"].as_u64().unwrap_or(0) > 0);
     }
 }

--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -38,8 +38,7 @@ impl SmartStrategy {
         let mut balances = HashMap::new();
         if let Some(tokens) = state["tokens"].as_array() {
             for t in tokens {
-                if let (Some(name), Some(amount)) =
-                    (t["token_type"].as_str(), t["amount"].as_i64())
+                if let (Some(name), Some(amount)) = (t["token_type"].as_str(), t["amount"].as_i64())
                 {
                     balances.insert(name.to_string(), amount);
                 }
@@ -52,9 +51,7 @@ impl SmartStrategy {
         let mut played = HashMap::new();
         if let Some(arr) = state["cards_played_per_tag_contract"].as_array() {
             for entry in arr {
-                if let (Some(tag), Some(count)) =
-                    (entry["tag"].as_str(), entry["count"].as_u64())
-                {
+                if let (Some(tag), Some(count)) = (entry["tag"].as_str(), entry["count"].as_u64()) {
                     played.insert(tag.to_string(), count as u32);
                 }
             }
@@ -127,7 +124,7 @@ impl SmartStrategy {
                     // Lighter harmful penalty: high-output cards with harmful side effects
                     // are still valuable as long as the contract's max isn't violated
                     // (which is checked separately in `card_contract_score`).
-                    score += if n >= 0.0 { -n * 1.5 } else { -n * 1.5 };
+                    score += -n * 1.5;
                 }
                 _ => {}
             }
@@ -178,7 +175,10 @@ impl SmartStrategy {
         tags_played: &HashMap<String, u32>,
     ) -> f64 {
         let mut score = 0.0;
-        let reqs = contract["requirements"].as_array().cloned().unwrap_or_default();
+        let reqs = contract["requirements"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
 
         if let Some(effects) = card["effects"].as_array() {
             for effect in effects {
@@ -484,9 +484,7 @@ impl SmartStrategy {
                 if req["requirement_type"].as_str() != Some("CardTagConstraint") {
                     continue;
                 }
-                if let (Some(max), Some(tag)) =
-                    (req["max"].as_f64(), req["tag"].as_str())
-                {
+                if let (Some(max), Some(tag)) = (req["max"].as_f64(), req["tag"].as_str()) {
                     let tagged = Self::deck_tag_count(cards, tag);
                     let banned = (tagged - max).max(0.0);
                     if banned / cycle_size > 0.5 {
@@ -689,7 +687,7 @@ impl SmartStrategy {
                     if let Some(min) = req["min"].as_f64() {
                         let deck_count = Self::deck_tag_count(cards, tag);
                         if deck_count < min {
-                            let tag_feasibility = (deck_count / min).min(1.0).max(0.0);
+                            let tag_feasibility = (deck_count / min).clamp(0.0, 1.0);
                             feasibility = feasibility.min(tag_feasibility);
                         }
                     }
@@ -830,14 +828,11 @@ impl SmartStrategy {
             })?;
             let worst_sacrifice =
                 Self::safe_sacrifice_index(cards, &sacrifice_indices, best_replacement)?;
-            let worst_target = target_indices
-                .iter()
-                .copied()
-                .min_by(|&a, &b| {
-                    Self::card_general_quality(&cards[a]["card"])
-                        .partial_cmp(&Self::card_general_quality(&cards[b]["card"]))
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })?;
+            let worst_target = target_indices.iter().copied().min_by(|&a, &b| {
+                Self::card_general_quality(&cards[a]["card"])
+                    .partial_cmp(&Self::card_general_quality(&cards[b]["card"]))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })?;
             return Some(json!({
                 "action_type": "ReplaceCard",
                 "target_card_index": worst_target,
@@ -872,10 +867,7 @@ impl SmartStrategy {
                 qa.partial_cmp(&qb).unwrap_or(std::cmp::Ordering::Equal)
             });
 
-        let worst_target = match worst_target {
-            Some(t) => t,
-            None => return None,
-        };
+        let worst_target = worst_target?;
 
         let replacement_q = Self::card_general_quality(&cards[best_replacement]["card"]);
         let target_q = Self::card_general_quality(&cards[worst_target]["card"]);
@@ -1064,8 +1056,7 @@ impl Strategy for SmartStrategy {
         //    skip PlayCard and fall through to DiscardCard to accumulate the required turns.
         let impossible_contract = state["cards"].as_array().is_some_and(|cards| {
             !state["active_contract"].is_null() && {
-                let turns_played =
-                    state["contract_turns_played"].as_u64().unwrap_or(0) as u32;
+                let turns_played = state["contract_turns_played"].as_u64().unwrap_or(0) as u32;
                 Self::is_contract_impossible(
                     &state["active_contract"],
                     cards,
@@ -1087,12 +1078,9 @@ impl Strategy for SmartStrategy {
                 .iter()
                 .find(|a| a["action_type"] == "DiscardCard")
             {
-                if let Some(action) = Self::choose_discard_card(
-                    discard,
-                    state,
-                    &token_balances,
-                    &tags_played,
-                ) {
+                if let Some(action) =
+                    Self::choose_discard_card(discard, state, &token_balances, &tags_played)
+                {
                     self.consecutive_discards
                         .set(self.consecutive_discards.get() + 1);
                     return action;
@@ -1101,7 +1089,9 @@ impl Strategy for SmartStrategy {
         }
 
         // 1. Deckbuild when available and beneficial.
-        if let Some(replace) = possible_actions.iter().find(|a| a["action_type"] == "ReplaceCard")
+        if let Some(replace) = possible_actions
+            .iter()
+            .find(|a| a["action_type"] == "ReplaceCard")
         {
             if let Some(action) = Self::choose_deckbuild_action(replace, state) {
                 return action;
@@ -1109,9 +1099,11 @@ impl Strategy for SmartStrategy {
         }
 
         // 2. Play the best-scoring card for the active contract.
-        if let Some(play) = possible_actions.iter().find(|a| a["action_type"] == "PlayCard") {
-            if let Some(action) =
-                Self::choose_play_card(play, state, &token_balances, &tags_played)
+        if let Some(play) = possible_actions
+            .iter()
+            .find(|a| a["action_type"] == "PlayCard")
+        {
+            if let Some(action) = Self::choose_play_card(play, state, &token_balances, &tags_played)
             {
                 self.consecutive_discards.set(0);
                 return action;

--- a/tests/starter_cards_test.rs
+++ b/tests/starter_cards_test.rs
@@ -4,6 +4,7 @@ use my_little_factory_manager::starter_cards::create_starter_deck;
 use my_little_factory_manager::types::{CardTag, TokenType};
 use rand::SeedableRng;
 use rand_pcg::Pcg64;
+use std::collections::BTreeSet;
 
 #[test]
 fn starter_deck_has_correct_size() {
@@ -30,7 +31,13 @@ fn all_starter_cards_are_pure_production() {
     let mut rng = Pcg64::seed_from_u64(42);
     let entries = create_starter_deck(50, &mut rng);
     for entry in &entries {
-        assert_eq!(entry.card.tags, vec![CardTag::Production]);
+        assert_eq!(
+            entry.card.tags,
+            vec![CardTag {
+                input: BTreeSet::new(),
+                output: BTreeSet::from([TokenType::ProductionUnit]),
+            }]
+        );
         assert_eq!(entry.card.effects.len(), 1);
         assert!(entry.card.effects[0].inputs.is_empty());
         assert_eq!(entry.card.effects[0].outputs.len(), 1);

--- a/tests/tier_progression_test.rs
+++ b/tests/tier_progression_test.rs
@@ -117,8 +117,8 @@ fn all_mains_have_at_least_one_tag() {
 
     for et in &effect_types {
         assert!(
-            !et.tags.is_empty(),
-            "main '{}' should have at least one tag",
+            !et.tag.input.is_empty() || !et.tag.output.is_empty(),
+            "main '{}' should have at least one token in its tag",
             et.name
         );
     }

--- a/tests/types_serialization_test.rs
+++ b/tests/types_serialization_test.rs
@@ -3,6 +3,7 @@ use my_little_factory_manager::types::{
     CardEffect, CardLocation, CardTag, Contract, ContractRequirementKind, ContractTier,
     PlayerActionCard, TokenAmount, TokenTag, TokenType,
 };
+use std::collections::BTreeSet;
 
 // ---------------------------------------------------------------------------
 // TokenType tests
@@ -199,7 +200,10 @@ fn token_requirement_max_serialization_roundtrip() {
 #[test]
 fn card_tag_constraint_serialization_roundtrip() {
     let req = ContractRequirementKind::CardTagConstraint {
-        tag: CardTag::Production,
+        tag: CardTag {
+            input: BTreeSet::new(),
+            output: BTreeSet::from([TokenType::ProductionUnit]),
+        },
         min: None,
         max: Some(0),
     };
@@ -280,10 +284,22 @@ fn card_location_serialization_roundtrip() {
 #[test]
 fn card_tag_serialization_roundtrip() {
     let tags = vec![
-        CardTag::Production,
-        CardTag::Transformation,
-        CardTag::QualityControl,
-        CardTag::SystemAdjustment,
+        CardTag {
+            input: BTreeSet::new(),
+            output: BTreeSet::from([TokenType::ProductionUnit]),
+        },
+        CardTag {
+            input: BTreeSet::from([TokenType::Heat]),
+            output: BTreeSet::new(),
+        },
+        CardTag {
+            input: BTreeSet::from([TokenType::Energy]),
+            output: BTreeSet::from([TokenType::ProductionUnit]),
+        },
+        CardTag {
+            input: BTreeSet::new(),
+            output: BTreeSet::new(),
+        },
     ];
     for tag in &tags {
         let json = serde_json::to_string(tag).expect("serialize CardTag");
@@ -299,7 +315,16 @@ fn card_tag_serialization_roundtrip() {
 #[test]
 fn player_action_card_serialization_roundtrip() {
     let card = PlayerActionCard {
-        tags: vec![CardTag::Production, CardTag::Transformation],
+        tags: vec![
+            CardTag {
+                input: BTreeSet::new(),
+                output: BTreeSet::from([TokenType::ProductionUnit]),
+            },
+            CardTag {
+                input: BTreeSet::from([TokenType::Energy]),
+                output: BTreeSet::from([TokenType::ProductionUnit]),
+            },
+        ],
         effects: vec![
             CardEffect::new(
                 vec![],
@@ -345,7 +370,10 @@ fn contract_serialization_roundtrip() {
             },
         ],
         reward_card: PlayerActionCard {
-            tags: vec![CardTag::Production],
+            tags: vec![CardTag {
+                input: BTreeSet::new(),
+                output: BTreeSet::from([TokenType::ProductionUnit]),
+            }],
             effects: vec![CardEffect::new(
                 vec![],
                 vec![


### PR DESCRIPTION
## Summary

- Replaces the coarse 4-variant `CardTag` enum (`Production`, `Transformation`, `QualityControl`, `SystemAdjustment`) with a struct `CardTag { input: BTreeSet<TokenType>, output: BTreeSet<TokenType> }` that captures exactly which tokens a card effect consumes and produces.
- Tags are derived automatically in `generate_effect_types()` from each effect's `primary_token` + `MainEffectDirection` (guarantees uniqueness per template). When `generate_reward_card_with_types` selects a specific variation, the card's tag is extended with the variation's secondary token, giving each generated card a precise signature.
- `unlocked_card_tags()` now enumerates all possible tags (base + every unlocked variation extension), so `CardTagConstraint` requirements can target fine-grained profiles (e.g. "at most 2 cards that output Heat") rather than the old broad categories that covered nearly every card.
- Fixes three pre-existing clippy warnings in `tests/simulation/strategies/smart_strategy.rs`.

## Breaking changes

| What | Before | After |
|---|---|---|
| `CardTag` serialization | `"Production"` (string) | `{"input":[],"output":["ProductionUnit"]}` (object) |
| `GET /library/cards?tag=` | `?tag=Production` | `?tag=%7B%22input%22%3A%5B%5D%2C%22output%22%3A%5B%22ProductionUnit%22%5D%7D` (URL-encoded JSON) |
| `token_definitions.json` | had `producer_tags`/`consumer_tags` fields | fields removed; tags are computed |
| `CardEffectTypeConfig` | `.tags: Vec<CardTag>` | `.tag: CardTag` (singular) |

Closes #31

## Test plan

- [x] `make check` passes (fmt, clippy, build, all tests, ≥80% coverage)
- [x] All existing tests updated to use new `CardTag` struct syntax
- [x] `library_cards_filter_by_production_tag` updated to use URL-encoded JSON tag query
- [x] `tier1_reward_cards_are_pure_production` updated to check token names in tag objects
- [x] `metrics_track_per_tag_counts` updated to check tag is a JSON object

🤖 Generated with [Claude Code](https://claude.ai/claude-code)