### PR TITLE
BREAKING: cache all immutable config-derived data in CachedConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@
 //! These types are deserialized from JSON files under `configurations/` at
 //! compile time and used to configure game behaviour.
 
+use std::collections::HashMap;
+
 use crate::types::{CardTag, MainEffectDirection, TokenType, VariationDirection};
 use rocket::serde::Deserialize;
 
@@ -194,6 +196,40 @@ pub struct CardEffectVariation {
     /// -1 = costs primary (removes harm / gets extra beneficial output).
     pub direction_sign: i8,
     pub unlock_tier: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Cached config: all immutable derived data pre-computed at game creation
+// ---------------------------------------------------------------------------
+
+/// All config-derived data pre-computed once when a new game is created.
+///
+/// Constructed via `contract_generation::build_cached_config`. Passed by
+/// reference to all generation functions so configs are never re-loaded
+/// or re-derived during a game.
+pub struct CachedConfig {
+    pub rules: GameRulesConfig,
+    pub token_defs: TokenDefinitionsConfig,
+    pub effect_types: Vec<CardEffectTypeConfig>,
+    pub unlocked_tokens_by_tier: HashMap<u32, Vec<TokenType>>,
+    pub unlocked_tags_by_tier: HashMap<u32, Vec<CardTag>>,
+    pub max_precomputed_tier: u32,
+}
+
+impl CachedConfig {
+    pub fn unlocked_tokens_at(&self, tier: u32) -> &[TokenType] {
+        let capped = tier.min(self.max_precomputed_tier);
+        self.unlocked_tokens_by_tier
+            .get(&capped)
+            .map_or(&[], Vec::as_slice)
+    }
+
+    pub fn unlocked_tags_at(&self, tier: u32) -> &[CardTag] {
+        let capped = tier.min(self.max_precomputed_tier);
+        self.unlocked_tags_by_tier
+            .get(&capped)
+            .map_or(&[], Vec::as_slice)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/contract_generation.rs
+++ b/src/contract_generation.rs
@@ -12,18 +12,18 @@
 use rand::RngCore;
 use rand_pcg::Pcg64;
 
+use std::collections::{BTreeSet, HashMap};
+
 use crate::adaptive_balance::AdaptiveBalanceTracker;
 use crate::config::{
-    CardEffectTypeConfig, CardEffectVariation, CardTagConstraintFormulaConfig,
-    ContractFormulasConfig, ModifierRange, TierScalingFormula, TokenDefinitionsConfig,
-    TurnWindowFormulaConfig, VariationDefaultsConfig,
+    CachedConfig, CardEffectTypeConfig, CardEffectVariation, CardTagConstraintFormulaConfig,
+    ContractFormulasConfig, GameRulesConfig, ModifierRange, TierScalingFormula,
+    TokenDefinitionsConfig, TurnWindowFormulaConfig, VariationDefaultsConfig,
 };
-use crate::config_loader::load_token_definitions;
 use crate::types::{
     CardEffect, CardTag, Contract, ContractRequirementKind, ContractTier, MainEffectDirection,
     PlayerActionCard, TokenAmount, TokenType, VariationDirection,
 };
-use std::collections::BTreeSet;
 
 type RequirementGenerator = Box<dyn Fn(&mut Pcg64) -> ContractRequirementKind>;
 
@@ -379,7 +379,7 @@ fn unlocked_card_tags(tier: u32, effect_types: &[CardEffectTypeConfig]) -> Vec<C
 fn available_requirement_generators(
     tier: u32,
     formulas: &ContractFormulasConfig,
-    effect_types: &[CardEffectTypeConfig],
+    cached_config: &CachedConfig,
 ) -> Vec<RequirementGenerator> {
     let mut generators: Vec<RequirementGenerator> = Vec::new();
 
@@ -388,8 +388,8 @@ fn available_requirement_generators(
     // guarantee the token's producer was unlocked a full tier before the contract
     // tier. `0.saturating_sub(2) == 0` keeps ProductionUnit (unlock tier 0) in
     // the tier-0 pool.
-    let beneficial_min_tokens = unlocked_token_types(tier.saturating_sub(2), effect_types);
-    for token in &beneficial_min_tokens {
+    let beneficial_min_tokens = cached_config.unlocked_tokens_at(tier.saturating_sub(2));
+    for token in beneficial_min_tokens {
         if token.is_beneficial() {
             let t = token.clone();
             let formula = formulas.output_threshold.clone();
@@ -405,8 +405,8 @@ fn available_requirement_generators(
 
     // Harmful max requirements: full current-tier set — safe because the player
     // only accumulates harmful tokens by playing cards that produce them.
-    let harmful_max_tokens = unlocked_token_types(tier, effect_types);
-    for token in &harmful_max_tokens {
+    let harmful_max_tokens = cached_config.unlocked_tokens_at(tier);
+    for token in harmful_max_tokens {
         if token.is_harmful() {
             let t = token.clone();
             let formula = formulas.harmful_token_limit.clone();
@@ -433,7 +433,7 @@ fn available_requirement_generators(
     // CardTagConstraint generator — unlocks in the Waste→QP gap
     if let Some(ctc_config) = formulas.card_tag_constraint.as_ref() {
         if tier >= ctc_config.unlock_tier_only_max {
-            let available_tags = unlocked_card_tags(tier, effect_types);
+            let available_tags = cached_config.unlocked_tags_at(tier).to_vec();
             if !available_tags.is_empty() {
                 let ctc = ctc_config.clone();
                 generators.push(Box::new(move |rng: &mut Pcg64| {
@@ -567,42 +567,62 @@ fn roll_requirement_tier(contract_tier: u32, rng: &mut Pcg64) -> u32 {
     min_tier + (rng.next_u32() % range)
 }
 
-/// Generate a single contract for the given tier.
-pub fn generate_contract(
-    tier: ContractTier,
-    rng: &mut Pcg64,
-    formulas: &ContractFormulasConfig,
-    adaptive_tracker: &AdaptiveBalanceTracker,
-) -> Contract {
-    let token_defs = load_token_definitions().expect("embedded token definitions must parse");
+/// Build a `CachedConfig` from raw configs, pre-computing all tier-derived data.
+///
+/// Pre-computes `unlocked_tokens_by_tier` and `unlocked_tags_by_tier` for
+/// tiers 0..=max_effect_tier+50 so that contract generation never re-derives
+/// these from config at runtime.
+pub fn build_cached_config(
+    rules: GameRulesConfig,
+    token_defs: TokenDefinitionsConfig,
+) -> CachedConfig {
     let effect_types = generate_effect_types(&token_defs);
-    generate_contract_with_types(
-        tier,
-        rng,
-        formulas,
-        &token_defs,
-        &effect_types,
-        adaptive_tracker,
-    )
+    let max_effect_tier = effect_types
+        .iter()
+        .map(|e| e.available_at_tier)
+        .max()
+        .unwrap_or(0);
+    let max_precomputed_tier = max_effect_tier + 50;
+
+    let unlocked_tokens_by_tier: HashMap<u32, Vec<TokenType>> = (0..=max_precomputed_tier)
+        .map(|t| (t, unlocked_token_types(t, &effect_types)))
+        .collect();
+    let unlocked_tags_by_tier: HashMap<u32, Vec<CardTag>> = (0..=max_precomputed_tier)
+        .map(|t| (t, unlocked_card_tags(t, &effect_types)))
+        .collect();
+
+    CachedConfig {
+        rules,
+        token_defs,
+        effect_types,
+        unlocked_tokens_by_tier,
+        unlocked_tags_by_tier,
+        max_precomputed_tier,
+    }
 }
 
-/// Generate a contract using explicit effect types (for testing).
+/// Generate a contract for the given tier using pre-computed cached config.
 pub fn generate_contract_with_types(
     tier: ContractTier,
     rng: &mut Pcg64,
-    formulas: &ContractFormulasConfig,
-    token_defs: &TokenDefinitionsConfig,
-    effect_types: &[CardEffectTypeConfig],
+    cached_config: &CachedConfig,
     adaptive_tracker: &AdaptiveBalanceTracker,
 ) -> Contract {
-    let generators_at_contract_tier =
-        available_requirement_generators(tier.0, formulas, effect_types);
+    let generators_at_contract_tier = available_requirement_generators(
+        tier.0,
+        &cached_config.rules.contract_formulas,
+        cached_config,
+    );
     let req_count = roll_requirement_count(tier.0, generators_at_contract_tier.len(), rng);
 
     let mut requirements = Vec::with_capacity(req_count);
     for _ in 0..req_count {
         let req_tier = roll_requirement_tier(tier.0, rng);
-        let generators = available_requirement_generators(req_tier, formulas, effect_types);
+        let generators = available_requirement_generators(
+            req_tier,
+            &cached_config.rules.contract_formulas,
+            cached_config,
+        );
         if generators.is_empty() {
             continue;
         }
@@ -613,8 +633,7 @@ pub fn generate_contract_with_types(
     // Apply adaptive balance overlay after base requirements are rolled
     let adaptive_adjustments = adaptive_tracker.apply_overlay(&mut requirements);
 
-    let reward_card =
-        generate_reward_card_with_types(tier, requirements.len(), rng, token_defs, effect_types);
+    let reward_card = generate_reward_card_with_types(tier, requirements.len(), rng, cached_config);
 
     Contract {
         tier,
@@ -633,10 +652,9 @@ pub fn generate_reward_card_with_types(
     tier: ContractTier,
     num_effects: usize,
     rng: &mut Pcg64,
-    token_defs: &TokenDefinitionsConfig,
-    effect_types: &[CardEffectTypeConfig],
+    cached_config: &CachedConfig,
 ) -> PlayerActionCard {
-    let choices = build_effect_choices(tier.0, effect_types);
+    let choices = build_effect_choices(tier.0, &cached_config.effect_types);
 
     let mut all_tags: Vec<CardTag> = Vec::new();
     let effects: Vec<CardEffect> = (0..num_effects)
@@ -663,7 +681,7 @@ pub fn generate_reward_card_with_types(
                     tier.0,
                     selected.root,
                     v,
-                    &token_defs.variation_defaults,
+                    &cached_config.token_defs.variation_defaults,
                     rng,
                 ),
                 None => roll_base_effect(tier.0, selected.root, rng),

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -11,9 +11,9 @@ use rand_pcg::Pcg64;
 
 use crate::action_log::{ActionLog, PlayerAction};
 use crate::adaptive_balance::AdaptiveBalanceTracker;
-use crate::config::{CardEffectTypeConfig, GameRulesConfig, TokenDefinitionsConfig};
+use crate::config::{CachedConfig, GameRulesConfig};
 use crate::config_loader::{load_game_rules, load_token_definitions};
-use crate::contract_generation::{generate_contract_with_types, generate_effect_types};
+use crate::contract_generation::{build_cached_config, generate_contract_with_types};
 use crate::metrics::{MetricsTracker, SessionMetrics};
 use crate::starter_cards::create_starter_deck;
 use crate::types::{
@@ -234,12 +234,8 @@ pub struct GameState {
     rng: Pcg64,
     seed: u64,
 
-    // Config
-    rules: GameRulesConfig,
-
-    // Precomputed effect types (cached at init for performance)
-    token_defs: TokenDefinitionsConfig,
-    effect_types: Vec<CardEffectTypeConfig>,
+    // All config-derived data, pre-computed once at game creation
+    cached_config: CachedConfig,
 
     // Action log
     action_log: ActionLog,
@@ -277,16 +273,24 @@ impl GameState {
             0xa02b_dbf7_bb3c_0a7a_c28f_5c28_f5c2_8f5c,
         );
 
-        let mut cards = create_starter_deck(rules.general.starting_deck_size, &mut rng);
+        let token_defs = load_token_definitions().expect("embedded token definitions must parse");
+        let cached_config = build_cached_config(rules, token_defs);
+
+        let mut cards = create_starter_deck(
+            cached_config.rules.general.starting_deck_size,
+            &mut rng,
+            &cached_config.effect_types,
+        );
 
         // Deal starting hand
-        let hand_size = rules.general.starting_hand_size;
+        let hand_size = cached_config.rules.general.starting_hand_size;
         for _ in 0..hand_size {
             draw_from_deck(&mut cards, &mut rng);
         }
 
-        let token_defs = load_token_definitions().expect("embedded token definitions must parse");
-        let effect_types = generate_effect_types(&token_defs);
+        let starting_deck_size = cached_config.rules.general.starting_deck_size;
+        let adaptive_tracker =
+            AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
         let mut state = Self {
             cards,
@@ -297,16 +301,14 @@ impl GameState {
             cards_played_per_tag_contract: HashMap::new(),
             rng,
             seed: actual_seed,
-            rules: rules.clone(),
-            token_defs,
-            effect_types,
+            cached_config,
             action_log: ActionLog::new(),
             metrics_tracker: MetricsTracker::new(),
-            adaptive_tracker: AdaptiveBalanceTracker::new(rules.adaptive_balance.clone()),
+            adaptive_tracker,
         };
 
         // Initialize deck slots to starting deck size
-        state.add_tokens(&TokenType::DeckSlots, rules.general.starting_deck_size);
+        state.add_tokens(&TokenType::DeckSlots, starting_deck_size);
 
         // Generate first offered contracts
         state.refill_contract_market();
@@ -453,7 +455,9 @@ impl GameState {
             }
 
             // AbandonContract becomes available after the minimum turns threshold
-            if self.contract_turns_played >= self.rules.general.min_turns_before_abandon {
+            if self.contract_turns_played
+                >= self.cached_config.rules.general.min_turns_before_abandon
+            {
                 actions.push(PossibleAction::AbandonContract);
             }
         } else {
@@ -619,7 +623,7 @@ impl GameState {
     // -------------------------------------------------------------------
 
     fn handle_new_game(&mut self, seed: Option<u64>) -> ActionResult {
-        let new_state = Self::new_with_rules(seed, self.rules.clone());
+        let new_state = Self::new_with_rules(seed, self.cached_config.rules.clone());
         let log = self.action_log.clone();
         *self = new_state;
         self.action_log = log;
@@ -751,7 +755,11 @@ impl GameState {
         self.cards[card_index].counts.hand -= 1;
         self.cards[card_index].counts.discard += 1;
 
-        let bonus = self.rules.general.discard_production_unit_bonus;
+        let bonus = self
+            .cached_config
+            .rules
+            .general
+            .discard_production_unit_bonus;
         *self.tokens.entry(TokenType::ProductionUnit).or_insert(0) += bonus;
 
         self.metrics_tracker
@@ -881,7 +889,7 @@ impl GameState {
             None => return ActionResult::Error(ActionError::NoContractToAbandon),
         };
 
-        let turns_required = self.rules.general.min_turns_before_abandon;
+        let turns_required = self.cached_config.rules.general.min_turns_before_abandon;
         if self.contract_turns_played < turns_required {
             return ActionResult::Error(ActionError::AbandonContractNotAllowed {
                 turns_played: self.contract_turns_played,
@@ -957,7 +965,11 @@ impl GameState {
     // -------------------------------------------------------------------
 
     fn refill_contract_market(&mut self) {
-        let target = self.rules.general.contract_market_size_per_tier;
+        let target = self
+            .cached_config
+            .rules
+            .general
+            .contract_market_size_per_tier;
 
         for tier_num in self.unlocked_tiers() {
             let tier = ContractTier(tier_num);
@@ -979,9 +991,7 @@ impl GameState {
                     generate_contract_with_types(
                         tier,
                         &mut self.rng,
-                        &self.rules.contract_formulas,
-                        &self.token_defs,
-                        &self.effect_types,
+                        &self.cached_config,
                         &self.adaptive_tracker,
                     )
                 })
@@ -1002,7 +1012,11 @@ impl GameState {
     /// Tier 0 is always unlocked. Tier N+1 unlocks when
     /// `ContractsTierCompleted(N) >= contracts_per_tier_to_advance`.
     fn unlocked_tiers(&self) -> Vec<u32> {
-        let threshold = self.rules.general.contracts_per_tier_to_advance;
+        let threshold = self
+            .cached_config
+            .rules
+            .general
+            .contracts_per_tier_to_advance;
         let mut tiers = vec![0u32];
         for tier in 0.. {
             let completed = self

--- a/src/starter_cards.rs
+++ b/src/starter_cards.rs
@@ -5,8 +5,8 @@
 
 use rand_pcg::Pcg64;
 
-use crate::config_loader::load_token_definitions;
-use crate::contract_generation::{generate_effect_types, roll_base_effect};
+use crate::config::CardEffectTypeConfig;
+use crate::contract_generation::roll_base_effect;
 use crate::types::{add_card_to_entries, CardEntry, CardLocation, PlayerActionCard};
 
 /// Build the starter deck by round-robin rolling `count` cards from all
@@ -14,10 +14,11 @@ use crate::types::{add_card_to_entries, CardEntry, CardLocation, PlayerActionCar
 ///
 /// Duplicate cards (same effects and tags) are grouped into a single
 /// `CardEntry` with the appropriate copy count.
-pub fn create_starter_deck(count: u32, rng: &mut Pcg64) -> Vec<CardEntry> {
-    let token_defs = load_token_definitions().expect("embedded token definitions must parse");
-    let effect_types = generate_effect_types(&token_defs);
-
+pub fn create_starter_deck(
+    count: u32,
+    rng: &mut Pcg64,
+    effect_types: &[CardEffectTypeConfig],
+) -> Vec<CardEntry> {
     let available: Vec<_> = effect_types
         .iter()
         .filter(|et| et.available_at_tier == 0)

--- a/tests/starter_cards_test.rs
+++ b/tests/starter_cards_test.rs
@@ -1,15 +1,23 @@
 //! Tests for the starter deck definitions.
 
+use my_little_factory_manager::config_loader::load_token_definitions;
+use my_little_factory_manager::contract_generation::generate_effect_types;
 use my_little_factory_manager::starter_cards::create_starter_deck;
 use my_little_factory_manager::types::{CardTag, TokenType};
 use rand::SeedableRng;
 use rand_pcg::Pcg64;
 use std::collections::BTreeSet;
 
+fn effect_types() -> Vec<my_little_factory_manager::config::CardEffectTypeConfig> {
+    let token_defs = load_token_definitions().expect("config");
+    generate_effect_types(&token_defs)
+}
+
 #[test]
 fn starter_deck_has_correct_size() {
     let mut rng = Pcg64::seed_from_u64(42);
-    let entries = create_starter_deck(50, &mut rng);
+    let et = effect_types();
+    let entries = create_starter_deck(50, &mut rng, &et);
     let total_cards: u32 = entries.iter().map(|e| e.counts.deck).sum();
     assert_eq!(total_cards, 50, "starter deck should have 50 total cards");
 }
@@ -17,7 +25,8 @@ fn starter_deck_has_correct_size() {
 #[test]
 fn all_copies_start_in_deck() {
     let mut rng = Pcg64::seed_from_u64(42);
-    let entries = create_starter_deck(50, &mut rng);
+    let et = effect_types();
+    let entries = create_starter_deck(50, &mut rng, &et);
     for entry in &entries {
         assert_eq!(entry.counts.shelved, 0);
         assert_eq!(entry.counts.hand, 0);
@@ -29,7 +38,8 @@ fn all_copies_start_in_deck() {
 #[test]
 fn all_starter_cards_are_pure_production() {
     let mut rng = Pcg64::seed_from_u64(42);
-    let entries = create_starter_deck(50, &mut rng);
+    let et = effect_types();
+    let entries = create_starter_deck(50, &mut rng, &et);
     for entry in &entries {
         assert_eq!(
             entry.card.tags,
@@ -51,7 +61,8 @@ fn all_starter_cards_are_pure_production() {
 #[test]
 fn starter_cards_production_amounts_in_tier0_range() {
     let mut rng = Pcg64::seed_from_u64(123);
-    let entries = create_starter_deck(50, &mut rng);
+    let et = effect_types();
+    let entries = create_starter_deck(50, &mut rng, &et);
     for entry in &entries {
         let amount = entry.card.effects[0].outputs[0].amount;
         // Tier 0 pure_production: base_min=1 + 0*per_tier_min=1 = 1,

--- a/tests/tier_progression_test.rs
+++ b/tests/tier_progression_test.rs
@@ -6,9 +6,11 @@
 //! beneficial-token-min one-tier delay invariant.
 
 use my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker;
+use my_little_factory_manager::config::CachedConfig;
 use my_little_factory_manager::config_loader::{load_game_rules, load_token_definitions};
 use my_little_factory_manager::contract_generation::{
-    generate_contract_with_types, generate_effect_types, generate_reward_card_with_types,
+    build_cached_config, generate_contract_with_types, generate_effect_types,
+    generate_reward_card_with_types,
 };
 use my_little_factory_manager::rocket_initialize;
 use my_little_factory_manager::types::{
@@ -22,6 +24,12 @@ use std::collections::HashMap;
 
 fn client() -> Client {
     Client::tracked(rocket_initialize()).expect("valid rocket instance")
+}
+
+fn make_cached_config() -> CachedConfig {
+    let token_defs = load_token_definitions().expect("config");
+    let game_rules = load_game_rules().expect("rules");
+    build_cached_config(game_rules, token_defs)
 }
 
 fn post_action(client: &Client, json: &str) -> serde_json::Value {
@@ -349,21 +357,14 @@ fn direction_sign_negative_for_beneficial_output_variation() {
 
 #[test]
 fn reward_card_variation_has_both_primary_and_secondary_tokens() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
+    let cached_config = make_cached_config();
 
     // Generate many reward cards and find one with a variation (non-empty inputs+outputs)
     let mut rng = Pcg64::seed_from_u64(42);
     let mut found_variation = false;
 
     for _ in 0..50 {
-        let card = generate_reward_card_with_types(
-            ContractTier(5),
-            3,
-            &mut rng,
-            &token_defs,
-            &effect_types,
-        );
+        let card = generate_reward_card_with_types(ContractTier(5), 3, &mut rng, &cached_config);
 
         for effect in &card.effects {
             let total_entries = effect.inputs.len() + effect.outputs.len();
@@ -385,26 +386,15 @@ fn reward_card_variation_has_both_primary_and_secondary_tokens() {
 
 #[test]
 fn reward_card_amounts_scale_with_tier() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
+    let cached_config = make_cached_config();
 
     let mut rng_low = Pcg64::seed_from_u64(42);
     let mut rng_high = Pcg64::seed_from_u64(42);
 
-    let low_tier_card = generate_reward_card_with_types(
-        ContractTier(0),
-        1,
-        &mut rng_low,
-        &token_defs,
-        &effect_types,
-    );
-    let high_tier_card = generate_reward_card_with_types(
-        ContractTier(20),
-        1,
-        &mut rng_high,
-        &token_defs,
-        &effect_types,
-    );
+    let low_tier_card =
+        generate_reward_card_with_types(ContractTier(0), 1, &mut rng_low, &cached_config);
+    let high_tier_card =
+        generate_reward_card_with_types(ContractTier(20), 1, &mut rng_high, &cached_config);
 
     let low_sum: u32 = low_tier_card
         .effects
@@ -442,23 +432,16 @@ fn reward_card_amounts_scale_with_tier() {
 
 #[test]
 fn harmful_token_limit_appears_in_generated_contracts() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     let mut found_limit = false;
 
     // Generate contracts at tiers where Heat is unlocked (tier >= 1)
     for seed in 0..100u64 {
         let mut rng = Pcg64::seed_from_u64(seed);
-        let contract = generate_contract_with_types(
-            ContractTier(3),
-            &mut rng,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let contract =
+            generate_contract_with_types(ContractTier(3), &mut rng, &cached_config, &adaptive);
 
         for req in &contract.requirements {
             if matches!(
@@ -481,20 +464,13 @@ fn harmful_token_limit_appears_in_generated_contracts() {
 
 #[test]
 fn harmful_token_limit_targets_harmful_tokens_only() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     for seed in 0..50u64 {
         let mut rng = Pcg64::seed_from_u64(seed);
-        let contract = generate_contract_with_types(
-            ContractTier(5),
-            &mut rng,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let contract =
+            generate_contract_with_types(ContractTier(5), &mut rng, &cached_config, &adaptive);
 
         for req in &contract.requirements {
             if let ContractRequirementKind::TokenRequirement {
@@ -519,20 +495,13 @@ fn harmful_token_limit_targets_harmful_tokens_only() {
 
 #[test]
 fn tier0_requirements_only_use_production_unit() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     for seed in 0..50u64 {
         let mut rng = Pcg64::seed_from_u64(seed);
-        let contract = generate_contract_with_types(
-            ContractTier(0),
-            &mut rng,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let contract =
+            generate_contract_with_types(ContractTier(0), &mut rng, &cached_config, &adaptive);
 
         for req in &contract.requirements {
             if let ContractRequirementKind::TokenRequirement {
@@ -568,23 +537,16 @@ fn tier0_requirements_only_use_production_unit() {
 
 #[test]
 fn higher_tier_contracts_can_reference_more_token_types() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     let mut tier0_tokens = std::collections::HashSet::new();
     let mut tier10_tokens = std::collections::HashSet::new();
 
     for seed in 0..100u64 {
         let mut rng0 = Pcg64::seed_from_u64(seed);
-        let c0 = generate_contract_with_types(
-            ContractTier(0),
-            &mut rng0,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let c0 =
+            generate_contract_with_types(ContractTier(0), &mut rng0, &cached_config, &adaptive);
         for req in &c0.requirements {
             if let ContractRequirementKind::TokenRequirement { token_type, .. } = req {
                 tier0_tokens.insert(format!("{:?}", token_type));
@@ -592,14 +554,8 @@ fn higher_tier_contracts_can_reference_more_token_types() {
         }
 
         let mut rng10 = Pcg64::seed_from_u64(seed + 1000);
-        let c10 = generate_contract_with_types(
-            ContractTier(10),
-            &mut rng10,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let c10 =
+            generate_contract_with_types(ContractTier(10), &mut rng10, &cached_config, &adaptive);
         for req in &c10.requirements {
             if let ContractRequirementKind::TokenRequirement { token_type, .. } = req {
                 tier10_tokens.insert(format!("{:?}", token_type));
@@ -658,30 +614,17 @@ fn contract_completion_subtracts_summed_requirements() {
 
 #[test]
 fn same_seed_same_tier_produces_identical_contracts() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     for tier in [0, 5, 10, 20] {
         let mut rng1 = Pcg64::seed_from_u64(42);
-        let c1 = generate_contract_with_types(
-            ContractTier(tier),
-            &mut rng1,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let c1 =
+            generate_contract_with_types(ContractTier(tier), &mut rng1, &cached_config, &adaptive);
 
         let mut rng2 = Pcg64::seed_from_u64(42);
-        let c2 = generate_contract_with_types(
-            ContractTier(tier),
-            &mut rng2,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
-        );
+        let c2 =
+            generate_contract_with_types(ContractTier(tier), &mut rng2, &cached_config, &adaptive);
 
         assert_eq!(
             format!("{:?}", c1.requirements),
@@ -698,9 +641,8 @@ fn same_seed_same_tier_produces_identical_contracts() {
 
 #[test]
 fn contracts_valid_across_many_tiers_and_seeds() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("rules");
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     for tier in [0, 1, 5, 10, 20, 30, 48] {
         for seed in [1, 42, 777, 12345] {
@@ -708,10 +650,8 @@ fn contracts_valid_across_many_tiers_and_seeds() {
             let contract = generate_contract_with_types(
                 ContractTier(tier),
                 &mut rng,
-                &game_rules.contract_formulas,
-                &token_defs,
-                &effect_types,
-                &AdaptiveBalanceTracker::new(game_rules.adaptive_balance.clone()),
+                &cached_config,
+                &adaptive,
             );
 
             assert!(
@@ -754,17 +694,13 @@ fn contracts_valid_across_many_tiers_and_seeds() {
 /// so tier 0 beneficial-min pool still includes it.
 #[test]
 fn beneficial_min_requirement_absent_at_token_producer_unlock_tier() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("game rules");
-    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
-        game_rules.adaptive_balance.clone(),
-    );
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     // Find (token, producer_unlock_tier) for each non-PU beneficial token.
     let beneficial_tokens: Vec<(TokenType, u32)> = {
         let mut seen = std::collections::HashMap::new();
-        for et in &effect_types {
+        for et in &cached_config.effect_types {
             if et.primary_token.is_beneficial()
                 && et.primary_token != TokenType::ProductionUnit
                 && matches!(et.main_direction, MainEffectDirection::Producer)
@@ -789,9 +725,7 @@ fn beneficial_min_requirement_absent_at_token_producer_unlock_tier() {
             let contract = generate_contract_with_types(
                 ContractTier(*unlock_tier),
                 &mut rng,
-                &game_rules.contract_formulas,
-                &token_defs,
-                &effect_types,
+                &cached_config,
                 &adaptive,
             );
 
@@ -819,16 +753,12 @@ fn beneficial_min_requirement_absent_at_token_producer_unlock_tier() {
 /// token must appear at least once so the feature is also reachable.
 #[test]
 fn beneficial_min_requirement_reachable_one_tier_after_unlock() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("game rules");
-    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
-        game_rules.adaptive_balance.clone(),
-    );
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     let beneficial_tokens: Vec<(TokenType, u32)> = {
         let mut seen = std::collections::HashMap::new();
-        for et in &effect_types {
+        for et in &cached_config.effect_types {
             if et.primary_token.is_beneficial()
                 && et.primary_token != TokenType::ProductionUnit
                 && matches!(et.main_direction, MainEffectDirection::Producer)
@@ -849,9 +779,7 @@ fn beneficial_min_requirement_reachable_one_tier_after_unlock() {
             let contract = generate_contract_with_types(
                 ContractTier(req_tier),
                 &mut rng,
-                &game_rules.contract_formulas,
-                &token_defs,
-                &effect_types,
+                &cached_config,
                 &adaptive,
             );
 
@@ -886,24 +814,14 @@ fn beneficial_min_requirement_reachable_one_tier_after_unlock() {
 /// should still be reachable as a beneficial-min requirement in tier-0 contracts.
 #[test]
 fn production_unit_min_requirement_reachable_at_tier_0() {
-    let token_defs = load_token_definitions().expect("config");
-    let effect_types = generate_effect_types(&token_defs);
-    let game_rules = load_game_rules().expect("game rules");
-    let adaptive = my_little_factory_manager::adaptive_balance::AdaptiveBalanceTracker::new(
-        game_rules.adaptive_balance.clone(),
-    );
+    let cached_config = make_cached_config();
+    let adaptive = AdaptiveBalanceTracker::new(cached_config.rules.adaptive_balance.clone());
 
     let mut found = false;
     for seed in 0u64..500 {
         let mut rng = Pcg64::seed_from_u64(seed);
-        let contract = generate_contract_with_types(
-            ContractTier(0),
-            &mut rng,
-            &game_rules.contract_formulas,
-            &token_defs,
-            &effect_types,
-            &adaptive,
-        );
+        let contract =
+            generate_contract_with_types(ContractTier(0), &mut rng, &cached_config, &adaptive);
 
         for req in &contract.requirements {
             if let ContractRequirementKind::TokenRequirement {


### PR DESCRIPTION
## Summary

- Introduces `CachedConfig` struct (`src/config.rs`) grouping all immutable config-derived data: rules, token_defs, effect_types, and per-tier token/tag lookup tables pre-computed at game creation
- Adds `build_cached_config(rules, token_defs) -> CachedConfig` in `contract_generation.rs` that pre-computes `unlocked_tokens_by_tier` and `unlocked_tags_by_tier` for tiers 0..=max_effect_tier+50
- `generate_contract_with_types`, `generate_reward_card_with_types`, and `available_requirement_generators` now accept `&CachedConfig` instead of separate config parameters — eliminating redundant per-call derivations
- `create_starter_deck` takes `effect_types: &[CardEffectTypeConfig]` instead of loading config internally
- Removes dead code `generate_contract` (was never called, loaded config on every invocation)
- `GameState` consolidates `rules`, `token_defs`, `effect_types` into a single `cached_config: CachedConfig` field

## Breaking changes

- `generate_contract_with_types(tier, rng, formulas, token_defs, effect_types, adaptive)` → `generate_contract_with_types(tier, rng, cached_config, adaptive)`
- `generate_reward_card_with_types(tier, n, rng, token_defs, effect_types)` → `generate_reward_card_with_types(tier, n, rng, cached_config)`
- `create_starter_deck(count, rng)` → `create_starter_deck(count, rng, effect_types)`
- `generate_contract` removed entirely

## Test plan

- [x] `make check` passes: fmt, clippy, build, all 159 tests, 85.57% line coverage (>80% threshold)
- [x] Determinism tests confirm identical game state for same seeds after refactor
- [x] Contract system tests confirm correct contract generation at all tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)