### PR TITLE
Simplify ReplaceCard action by deferring index validation

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -203,11 +203,7 @@ pub enum PossibleAction {
     AcceptContract {
         valid_tiers: Vec<TierContractRange>,
     },
-    ReplaceCard {
-        valid_target_card_indices: Vec<usize>,
-        valid_replacement_card_indices: Vec<usize>,
-        valid_sacrifice_card_indices: Vec<usize>,
-    },
+    ReplaceCard,
     /// Available when an active contract has been running for at least
     /// `min_turns_before_abandon` turns. Abandoning counts as a failure.
     AbandonContract,
@@ -493,52 +489,19 @@ impl GameState {
         actions
     }
 
-    /// Adds a single ReplaceCard action descriptor with valid index sets.
+    /// Adds ReplaceCard action if it's possible.
     fn add_replace_card_action(&self, actions: &mut Vec<PossibleAction>) {
-        // Collect shelved card indices (cards with copies on the shelf)
-        let shelved_indices: Vec<usize> = self
+        // ReplaceCard is possible if there are cards with shelved copies (for replacement and sacrifice)
+        // and cards with copies in deck or discard (for target).
+        let has_shelved = self.cards.iter().any(|e| e.counts.has_shelved());
+        let has_target = self
             .cards
             .iter()
-            .enumerate()
-            .filter(|(_, e)| e.counts.has_shelved())
-            .map(|(i, _)| i)
-            .collect();
+            .any(|e| e.counts.deck > 0 || e.counts.discard > 0);
 
-        if shelved_indices.is_empty() {
-            return;
+        if has_shelved && has_target {
+            actions.push(PossibleAction::ReplaceCard);
         }
-
-        // Target cards: any card with copies in deck or discard
-        let target_indices: Vec<usize> = self
-            .cards
-            .iter()
-            .enumerate()
-            .filter(|(_, e)| e.counts.deck > 0 || e.counts.discard > 0)
-            .map(|(i, _)| i)
-            .collect();
-
-        if target_indices.is_empty() {
-            return;
-        }
-
-        // Sacrifice candidates: any card with copies on the shelf
-        let sacrifice_indices: Vec<usize> = self
-            .cards
-            .iter()
-            .enumerate()
-            .filter(|(_, e)| e.counts.has_shelved())
-            .map(|(i, _)| i)
-            .collect();
-
-        if sacrifice_indices.is_empty() {
-            return;
-        }
-
-        actions.push(PossibleAction::ReplaceCard {
-            valid_target_card_indices: target_indices,
-            valid_replacement_card_indices: shelved_indices,
-            valid_sacrifice_card_indices: sacrifice_indices,
-        });
     }
 
     /// Returns the set of card indices (into the cards Vec) that may currently be played.

--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -739,24 +739,32 @@ impl SmartStrategy {
 
     // Action builders
 
-    fn choose_deckbuild_action(
-        &self,
-        target_indices_raw: &[usize],
-        replacement_indices_raw: &[usize],
-        sacrifice_indices_raw: &[usize],
-        state: &GameStateView,
-    ) -> Option<PlayerAction> {
+    fn choose_deckbuild_action(&self, state: &GameStateView) -> Option<PlayerAction> {
         let cards = &state.cards;
-        let hash_to_index = self.process_new_arrivals(cards, replacement_indices_raw);
 
-        let target_indices = target_indices_raw.to_vec();
+        // Collect valid indices based on card availability
+        let replacement_indices_all: Vec<usize> = cards
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.counts.has_shelved())
+            .map(|(i, _)| i)
+            .collect();
+        let hash_to_index = self.process_new_arrivals(cards, &replacement_indices_all);
+
+        let target_indices: Vec<usize> = cards
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.counts.deck > 0 || e.counts.discard > 0)
+            .map(|(i, _)| i)
+            .collect();
+
         // Pass 1 uses a capped list; token production has no direct tag correlation
-        let replacement_indices: Vec<usize> = replacement_indices_raw
+        let replacement_indices: Vec<usize> = replacement_indices_all
             .iter()
             .copied()
             .take(PASS1_CANDIDATES)
             .collect();
-        let sacrifice_indices = sacrifice_indices_raw.to_vec();
+        let sacrifice_indices = replacement_indices_all.clone();
 
         if replacement_indices.is_empty() || target_indices.is_empty() {
             return None;
@@ -780,7 +788,7 @@ impl SmartStrategy {
                     &sacrifice_indices,
                     replacement,
                     &hash_to_index,
-                    replacement_indices_raw,
+                    &replacement_indices_all,
                 )?;
                 return Some(PlayerAction::ReplaceCard {
                     target_card_index: worst_target,
@@ -831,7 +839,7 @@ impl SmartStrategy {
             &sacrifice_indices,
             best_replacement,
             &hash_to_index,
-            replacement_indices_raw,
+            &replacement_indices_all,
         )?;
         Some(PlayerAction::ReplaceCard {
             target_card_index: worst_target,
@@ -1031,20 +1039,11 @@ impl Strategy for SmartStrategy {
         }
 
         // 1. Deckbuild when available and beneficial.
-        if let Some(PossibleAction::ReplaceCard {
-            valid_target_card_indices,
-            valid_replacement_card_indices,
-            valid_sacrifice_card_indices,
-        }) = possible_actions
+        if possible_actions
             .iter()
-            .find(|a| matches!(a, PossibleAction::ReplaceCard { .. }))
+            .any(|a| matches!(a, PossibleAction::ReplaceCard))
         {
-            if let Some(action) = self.choose_deckbuild_action(
-                valid_target_card_indices,
-                valid_replacement_card_indices,
-                valid_sacrifice_card_indices,
-                state,
-            ) {
+            if let Some(action) = self.choose_deckbuild_action(state) {
                 return action;
             }
         }


### PR DESCRIPTION
## Summary
This PR simplifies the `ReplaceCard` action by removing pre-computed valid card indices from the action descriptor. Instead of calculating and storing all valid target, replacement, and sacrifice card indices when generating possible actions, the strategy now computes these indices on-demand when actually choosing a deckbuild action.

## Key Changes

- **Simplified `PossibleAction::ReplaceCard` enum variant**: Removed the three `Vec<usize>` fields (`valid_target_card_indices`, `valid_replacement_card_indices`, `valid_sacrifice_card_indices`) and made it a unit variant. The action now only indicates that a replace card action is possible.

- **Deferred index validation**: Moved the logic for collecting valid card indices from `add_replace_card_action()` into `SmartStrategy::choose_deckbuild_action()`. The strategy now computes these indices only when needed, rather than storing them in the action descriptor.

- **Simplified action generation**: The `add_replace_card_action()` method now only checks if replacement is possible (cards with shelved copies exist) and if targets are available (cards in deck or discard exist), without collecting the actual indices.

- **Updated strategy logic**: Modified `SmartStrategy::choose_deckbuild_action()` to accept only the game state and internally compute all necessary card indices, eliminating the need to pass pre-computed index vectors as parameters.

## Implementation Details

- The feasibility check for `ReplaceCard` remains the same: it's only possible when there are both shelved cards (for replacement/sacrifice) and cards in deck/discard (for targets).
- All index collection logic is now centralized in the strategy's decision-making code, making it easier to maintain and modify validation rules in the future.
- The change reduces the size of action descriptors and avoids redundant index collection when a replace card action is not ultimately chosen.

https://claude.ai/code/session_01N7rjSgFoLz9quZ4fUdjeGW