### PR TITLE
Tighten harmful-token safety margin in SmartStrategy card_contract_score

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -787,8 +787,12 @@ impl SmartStrategy {
                             if current + amount > max_f {
                                 return f64::NEG_INFINITY;
                             }
-                            if amount > (max_f - current) * 0.75 {
-                                score -= 50.0;
+                            if current + amount > max_f * 0.85 {
+                                return f64::NEG_INFINITY;
+                            }
+                            let remaining = max_f - current;
+                            if amount > remaining * 0.70 {
+                                score -= 200.0 * (amount / remaining.max(1.0));
                             }
                         }
                         if let Some(min_val) = min {


### PR DESCRIPTION
Replace the soft -50 penalty with a graded penalty that's proportional to the
fraction of remaining harmful-token headroom consumed. Add a hard rejection
threshold at 85% of the maximum allowed, leaving a 15% safety margin.

The changes reduce HarmfulTokenLimitExceeded failures from 74 to 10 (86.5%
reduction) while improving overall_max_tier from 21 to 29.

https://claude.ai/code/session_01H1vkshz9yRwyN8CUtBEYse