### PR TITLE
Tighten is_contract_impossible safety factors from 0.5 to 0.7

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -17,6 +17,7 @@ const DISCARD_STUCK_THRESHOLD: u32 = 50;
 const TOP_N: usize = 30;
 const BOTTOM_N: usize = 30;
 const PASS1_CANDIDATES: usize = 200;
+const SAFETY_MARGIN: f64 = 0.7;
 
 /// Contract-aware strategy with active deckbuilding.
 ///
@@ -449,7 +450,7 @@ impl SmartStrategy {
                             return true;
                         }
                         let mean_prod = Self::deck_effective_production(cards, token_type);
-                        if turns_left * mean_prod < remaining * 0.5 {
+                        if turns_left * mean_prod < remaining * SAFETY_MARGIN {
                             return true;
                         }
                     }
@@ -496,7 +497,7 @@ impl SmartStrategy {
                             continue;
                         }
                         let turns_to_complete = remaining / mean_beneficial_prod;
-                        if turns_to_overflow < turns_to_complete * 0.5 {
+                        if turns_to_overflow < turns_to_complete * SAFETY_MARGIN {
                             return true;
                         }
                     }


### PR DESCRIPTION
Replace two hardcoded 0.5 literals with a named SAFETY_MARGIN constant (0.7),
causing the SmartStrategy to abandon doomed contracts a few turns earlier and
return the action budget to higher-tier attempts.

https://claude.ai/code/session_01HPZvbdsY6AJn1sx7X2RVqo