### PR TITLE
Implement TurnWindow penalty in SmartStrategy score_contract

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -725,7 +725,38 @@ impl SmartStrategy {
                         }
                     }
                 }
-                ContractRequirementKind::TurnWindow { .. } => {}
+                ContractRequirementKind::TurnWindow { max_turn, .. } => {
+                    if let Some(max_turn_val) = max_turn {
+                        let max_turn_f = *max_turn_val as f64;
+                        let mut tightest_ratio = 0.0f64;
+
+                        for req in &contract.requirements {
+                            if let ContractRequirementKind::TokenRequirement {
+                                token_type,
+                                min: Some(min_val),
+                                ..
+                            } = req
+                            {
+                                let current = *token_balances.get(token_type).unwrap_or(&0) as f64;
+                                let needed = (*min_val as f64 - current).max(0.0);
+                                if needed > 0.0 {
+                                    let mean_prod =
+                                        Self::deck_effective_production(cards, token_type);
+                                    if mean_prod > 0.0 {
+                                        let turns_needed = needed / mean_prod;
+                                        let ratio = turns_needed / max_turn_f;
+                                        tightest_ratio = tightest_ratio.max(ratio);
+                                    }
+                                }
+                            }
+                        }
+
+                        if tightest_ratio > 0.7 {
+                            let excess = (tightest_ratio - 0.7).min(1.0);
+                            feasibility = feasibility.min(1.0 - excess);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Add logic to penalize contracts with tight TurnWindow constraints. For each
TokenRequirement with a non-zero min, compute the turns needed based on current
balance and mean production rate. Track the tightest ratio across requirements.

If the tightest ratio exceeds 0.7 (requiring more than 70% of max_turn to meet
the requirement), apply a feasibility penalty that scales from 0.7 feasibility
at ratio ~1.0 to near-zero feasibility at ratio > 1.4.

This addresses the issue that score_contract was ignoring TurnWindow constraints,
allowing the strategy to accept contracts whose deadlines are too tight for the
deck's production capacity, resulting in predictable TurnWindowExceeded failures.

Implements issue #50.

https://claude.ai/code/session_01FZBvUA6sgTcNER5EATeiEi