### PR TITLE
Add turn urgency multiplier to contract scoring

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -766,7 +766,24 @@ impl SmartStrategy {
         contract: &Contract,
         token_balances: &HashMap<TokenType, i64>,
         tags_played: &HashMap<CardTag, u32>,
+        contract_turns_played: u32,
     ) -> f64 {
+        let urgency = contract
+            .requirements
+            .iter()
+            .find_map(|r| {
+                if let ContractRequirementKind::TurnWindow {
+                    max_turn: Some(m), ..
+                } = r
+                {
+                    let left = (*m as i64 - contract_turns_played as i64).max(1) as f64;
+                    Some((1.0 + (8.0 / left)).min(4.0))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(1.0);
+
         let mut score = 0.0;
         for effect in &card.effects {
             for output in &effect.outputs {
@@ -798,7 +815,7 @@ impl SmartStrategy {
                         if let Some(min_val) = min {
                             let needed = (*min_val as f64 - current).max(0.0);
                             if needed > 0.0 {
-                                score += amount.min(needed) * 5.0;
+                                score += amount.min(needed) * 5.0 * urgency;
                             }
                         }
                     }
@@ -976,7 +993,13 @@ impl SmartStrategy {
                     return (i, f64::NEG_INFINITY);
                 }
                 let score = if let Some(contract) = &state.active_contract {
-                    Self::card_contract_score(card, contract, token_balances, tags_played)
+                    Self::card_contract_score(
+                        card,
+                        contract,
+                        token_balances,
+                        tags_played,
+                        state.contract_turns_played,
+                    )
                 } else {
                     Self::card_general_quality(card)
                 };
@@ -1001,6 +1024,7 @@ impl SmartStrategy {
                     contract,
                     token_balances,
                     tags_played,
+                    state.contract_turns_played,
                 )
             } else {
                 Self::card_general_quality(&state.cards[idx].card)


### PR DESCRIPTION
## Summary
This change improves the card scoring logic for active contracts by introducing a turn-based urgency multiplier. When a contract has a turn window limit, the scoring now increases as the deadline approaches, encouraging the strategy to prioritize contract completion before time runs out.

## Key Changes
- Added `contract_turns_played` parameter to `card_contract_score()` method to track progress toward contract deadlines
- Implemented urgency calculation that examines contract requirements for `TurnWindow` constraints with maximum turn limits
- Urgency multiplier ranges from 1.0 (no deadline pressure) to 4.0 (critical deadline), calculated as `(1.0 + (8.0 / turns_left)).min(4.0)`
- Applied urgency multiplier to token requirement scoring, making contract-required tokens more valuable as the deadline approaches
- Updated all call sites to pass `state.contract_turns_played` to the scoring function

## Implementation Details
- The urgency calculation uses a logarithmic-like curve that accelerates scoring pressure as turns remaining decrease
- If no turn window constraint exists, urgency defaults to 1.0 (no multiplier effect)
- The multiplier specifically affects the scoring of cards that help fulfill token requirements for contracts with turn limits

https://claude.ai/code/session_018SwzLwKw6AitF1v3tu6hxd