### PR TITLE
Add per-tier contract outcome tracking to simulation reports

### DIFF
--- a/tests/simulation/game_driver.rs
+++ b/tests/simulation/game_driver.rs
@@ -46,6 +46,9 @@ pub struct GameResult {
     pub contracts_abandoned: u32,
     /// Count of each contract failure reason observed.
     pub failure_reasons: HashMap<String, u32>,
+    pub completed_per_tier: HashMap<u32, u32>,
+    pub failed_per_tier: HashMap<u32, u32>,
+    pub abandoned_per_tier: HashMap<u32, u32>,
     /// True when max_actions was exhausted before all milestones were reached.
     pub hit_action_limit: bool,
     /// True when no non-NewGame actions were available (invariant broken).
@@ -63,6 +66,9 @@ impl GameResult {
             contracts_failed: 0,
             contracts_abandoned: 0,
             failure_reasons: HashMap::new(),
+            completed_per_tier: HashMap::new(),
+            failed_per_tier: HashMap::new(),
+            abandoned_per_tier: HashMap::new(),
             hit_action_limit: false,
             stuck: false,
         }
@@ -138,6 +144,7 @@ impl GameDriver {
                         ContractResolution::Completed { contract } => {
                             let tier = contract.tier.0;
                             result.contracts_completed += 1;
+                            *result.completed_per_tier.entry(tier).or_insert(0) += 1;
                             result.max_tier_reached =
                                 Some(result.max_tier_reached.map_or(tier, |t: u32| t.max(tier)));
 
@@ -150,8 +157,10 @@ impl GameDriver {
                                 });
                             }
                         }
-                        ContractResolution::Failed { reason, .. } => {
+                        ContractResolution::Failed { contract, reason } => {
+                            let tier = contract.tier.0;
                             result.contracts_failed += 1;
+                            *result.failed_per_tier.entry(tier).or_insert(0) += 1;
                             let failure_type = match reason {
                                 ContractFailureReason::HarmfulTokenLimitExceeded { .. } => {
                                     "HarmfulTokenLimitExceeded"
@@ -161,6 +170,7 @@ impl GameDriver {
                                 }
                                 ContractFailureReason::Abandoned { .. } => {
                                     result.contracts_abandoned += 1;
+                                    *result.abandoned_per_tier.entry(tier).or_insert(0) += 1;
                                     "Abandoned"
                                 }
                             }

--- a/tests/simulation/runner.rs
+++ b/tests/simulation/runner.rs
@@ -49,6 +49,9 @@ pub struct StrategyReport {
     pub total_contracts_abandoned: u64,
     /// Top contract failure reasons sorted by frequency (descending).
     pub top_failure_reasons: Vec<(String, u64)>,
+    pub completed_per_tier: HashMap<u32, u64>,
+    pub failed_per_tier: HashMap<u32, u64>,
+    pub abandoned_per_tier: HashMap<u32, u64>,
     pub stuck_games: u32,
     pub action_limit_games: u32,
 }
@@ -153,6 +156,21 @@ impl SimulationRunner {
         let mut top_failure_reasons: Vec<(String, u64)> = failure_totals.into_iter().collect();
         top_failure_reasons.sort_by_key(|a| Reverse(a.1));
 
+        let mut completed_per_tier: HashMap<u32, u64> = HashMap::new();
+        let mut failed_per_tier: HashMap<u32, u64> = HashMap::new();
+        let mut abandoned_per_tier: HashMap<u32, u64> = HashMap::new();
+        for result in &results {
+            for (&tier, &count) in &result.completed_per_tier {
+                *completed_per_tier.entry(tier).or_insert(0) += u64::from(count);
+            }
+            for (&tier, &count) in &result.failed_per_tier {
+                *failed_per_tier.entry(tier).or_insert(0) += u64::from(count);
+            }
+            for (&tier, &count) in &result.abandoned_per_tier {
+                *abandoned_per_tier.entry(tier).or_insert(0) += u64::from(count);
+            }
+        }
+
         let stuck_games = results.iter().filter(|r| r.stuck).count() as u32;
         let action_limit_games = results.iter().filter(|r| r.hit_action_limit).count() as u32;
 
@@ -165,6 +183,9 @@ impl SimulationRunner {
             total_contracts_failed,
             total_contracts_abandoned,
             top_failure_reasons,
+            completed_per_tier,
+            failed_per_tier,
+            abandoned_per_tier,
             stuck_games,
             action_limit_games,
         }


### PR DESCRIPTION
## Summary
This PR adds granular tracking of contract outcomes (completed, failed, abandoned) broken down by contract tier to both individual game results and aggregated simulation reports.

## Key Changes
- **GameResult struct**: Added three new `HashMap` fields to track contract outcomes per tier:
  - `completed_per_tier`: Maps tier to count of completed contracts
  - `failed_per_tier`: Maps tier to count of failed contracts
  - `abandoned_per_tier`: Maps tier to count of abandoned contracts

- **GameDriver implementation**: Updated contract resolution handling to populate per-tier tracking:
  - When a contract completes, increment the corresponding tier in `completed_per_tier`
  - When a contract fails, increment the corresponding tier in `failed_per_tier`
  - When a contract is abandoned, increment the corresponding tier in `abandoned_per_tier`
  - Fixed pattern matching on `ContractResolution::Failed` to extract the contract tier

- **StrategyReport struct**: Added the same three per-tier tracking fields to aggregate results across all games in a simulation run

- **SimulationRunner implementation**: Added aggregation logic to sum per-tier outcomes from all individual game results into the final strategy report

## Implementation Details
- Per-tier counts use `u32` at the game level and `u64` at the report level (with conversion during aggregation)
- HashMap entries are created on-demand using `entry().or_insert(0)` pattern
- Aggregation properly handles multiple games by iterating through all results and summing counts for each tier

https://claude.ai/code/session_015zZhuPSQhSHKBX5oTgDVT1