### PR TITLE
Add target_progression_contract method to SmartStrategy

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -1196,6 +1196,48 @@ impl SmartStrategy {
             .map(|idx| PlayerAction::DiscardCard { card_index: idx })
     }
 
+    fn target_progression_contract<'a>(
+        offered: &'a [TierContracts],
+        cards: &[CardEntry],
+        token_balances: &HashMap<TokenType, i64>,
+    ) -> Option<&'a Contract> {
+        /// Tier weight when picking the stockpile target.
+        /// Lower than score_contract::TIER_WEIGHT — we deliberately want
+        /// reward quality to compete with raw tier preference.
+        const TARGET_TIER_WEIGHT: f64 = 1_500.0;
+
+        offered
+            .iter()
+            .flat_map(|tg| tg.contracts.iter())
+            .filter(|c| !Self::is_contract_impossible(c, cards, token_balances, 0))
+            .filter(|c| {
+                c.requirements.iter().any(|req| {
+                    if let ContractRequirementKind::TokenRequirement {
+                        token_type,
+                        min: Some(m),
+                        ..
+                    } = req
+                    {
+                        let cur = *token_balances.get(token_type).unwrap_or(&0) as f64;
+                        *m as f64 > cur
+                    } else {
+                        false
+                    }
+                })
+            })
+            .max_by(|a, b| {
+                let score = |c: &Contract| -> f64 {
+                    let base = Self::card_general_quality(&c.reward_card);
+                    let tag = Self::tag_diversity_bonus(&c.reward_card, cards);
+                    let tok = Self::token_diversity_bonus(&c.reward_card, cards);
+                    c.tier.0 as f64 * TARGET_TIER_WEIGHT + base + tag + tok
+                };
+                score(a)
+                    .partial_cmp(&score(b))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+
     fn choose_accept_contract(
         valid_tiers: &[my_little_factory_manager::game_state::TierContractRange],
         state: &GameStateView,


### PR DESCRIPTION
## Summary
Added a new method `target_progression_contract` to the `SmartStrategy` implementation that identifies the best contract to target for stockpile progression based on token requirements and reward quality.

## Key Changes
- Implemented `target_progression_contract` method that:
  - Filters contracts from offered tiers to find those that are not impossible to complete
  - Further filters to only contracts with unfulfilled token requirements (where current balance is below the minimum required)
  - Scores remaining contracts based on:
    - Tier weight (1,500.0) — deliberately lower than `score_contract::TIER_WEIGHT` to allow reward quality to compete with tier preference
    - Card general quality of the reward
    - Tag diversity bonus from the reward card
    - Token diversity bonus from the reward card
  - Returns the contract with the highest combined score

## Implementation Details
- Uses a `TARGET_TIER_WEIGHT` constant set to 1,500.0 to balance tier preference against reward quality metrics
- Filters for contracts with `TokenRequirement` that have an unfulfilled minimum token balance
- Employs `max_by` with `partial_cmp` for scoring comparison, defaulting to `Equal` for incomparable values
- Follows the existing pattern of quality assessment methods already present in `SmartStrategy`

https://claude.ai/code/session_01GKLHyHU2QVNxKYqbD1q3So