### PR TITLE
Add tier look-ahead logic for token acquisition in SmartStrategy

### DIFF
--- a/tests/simulation/strategies/smart_strategy.rs
+++ b/tests/simulation/strategies/smart_strategy.rs
@@ -591,6 +591,24 @@ impl SmartStrategy {
         comfort
     }
 
+    fn highest_offered_tier(offered: &[TierContracts]) -> u32 {
+        offered.iter().map(|tg| tg.tier.0).max().unwrap_or(0)
+    }
+
+    fn beneficial_tokens_unlocked_by(target_tier: u32) -> Vec<TokenType> {
+        let mut tokens = vec![TokenType::ProductionUnit];
+        if target_tier >= 4 {
+            tokens.push(TokenType::Energy);
+        }
+        if target_tier >= 16 {
+            tokens.push(TokenType::QualityPoint);
+        }
+        if target_tier >= 36 {
+            tokens.push(TokenType::Innovation);
+        }
+        tokens
+    }
+
     fn tokens_needed_for_advancement(
         cards: &[CardEntry],
         offered: &[TierContracts],
@@ -615,6 +633,18 @@ impl SmartStrategy {
                 }
             }
         }
+
+        // Look-ahead for tokens unlocking at tier+2
+        let highest_tier = Self::highest_offered_tier(offered);
+        let lookahead_tokens = Self::beneficial_tokens_unlocked_by(highest_tier + 2);
+        for token_type in lookahead_tokens {
+            if !needed.contains(&token_type)
+                && Self::deck_producing_copy_count(cards, &token_type) < MIN_COPIES
+            {
+                needed.push(token_type);
+            }
+        }
+
         needed
     }
 
@@ -640,6 +670,19 @@ impl SmartStrategy {
                 }
             }
         }
+
+        // Look-ahead for tokens unlocking at tier+2
+        let highest_tier = Self::highest_offered_tier(offered);
+        let lookahead_tokens = Self::beneficial_tokens_unlocked_by(highest_tier + 2);
+        for token_type in lookahead_tokens {
+            if !needed.contains(&token_type)
+                && Self::shelved_producing_card_count(cards, &token_type) > 0
+                && Self::deck_producing_copy_count(cards, &token_type) < MIN
+            {
+                needed.push(token_type);
+            }
+        }
+
         needed
     }
 


### PR DESCRIPTION
## Summary
Enhanced the SmartStrategy simulation to look ahead at tokens that will unlock at tier+2, ensuring the strategy proactively acquires necessary token producers before reaching those tiers.

## Key Changes
- **New helper method `highest_offered_tier()`**: Determines the maximum tier available in the current tier contracts offered
- **New helper method `beneficial_tokens_unlocked_by()`**: Returns the list of beneficial tokens that unlock at a given tier threshold (ProductionUnit at tier 0, Energy at tier 4, QualityPoint at tier 16, Innovation at tier 36)
- **Enhanced `tokens_needed_for_advancement()`**: Added look-ahead logic to identify tokens that will unlock at tier+2 and ensure minimum deck copies are acquired if not already needed
- **Enhanced `tokens_needed_for_shelving()`**: Added similar look-ahead logic to identify tokens unlocking at tier+2 and prioritize shelving cards that produce those tokens if deck copies are below minimum threshold

## Implementation Details
The look-ahead mechanism checks two tiers ahead (tier+2) to proactively prepare for upcoming token unlocks. This prevents the strategy from being caught unprepared when advancing to higher tiers and ensures smoother progression by acquiring token producers in advance.

https://claude.ai/code/session_01NitHSt8PzfV8opYnpRwr1B