### PR TITLE
Add stall detection to game simulation runner

### DIFF
--- a/tests/simulation/game_driver.rs
+++ b/tests/simulation/game_driver.rs
@@ -34,6 +34,14 @@ pub struct MilestoneResult {
     pub actions_to_reach: u64,
 }
 
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ExitReason {
+    Completed,
+    ActionLimitExceeded,
+    StallDetected,
+}
+
 /// Results from one complete simulated game.
 #[derive(Debug, Clone, Serialize)]
 pub struct GameResult {
@@ -53,6 +61,7 @@ pub struct GameResult {
     pub hit_action_limit: bool,
     /// True when no non-NewGame actions were available (invariant broken).
     pub stuck: bool,
+    pub exit_reason: ExitReason,
 }
 
 impl GameResult {
@@ -71,6 +80,7 @@ impl GameResult {
             abandoned_per_tier: HashMap::new(),
             hit_action_limit: false,
             stuck: false,
+            exit_reason: ExitReason::Completed,
         }
     }
 }
@@ -80,6 +90,7 @@ impl GameResult {
 pub struct GameDriver {
     pub max_actions: u64,
     pub milestone_tiers: Vec<u32>,
+    pub max_contracts_without_tier_progress: u64,
 }
 
 impl GameDriver {
@@ -87,7 +98,13 @@ impl GameDriver {
         Self {
             max_actions,
             milestone_tiers,
+            max_contracts_without_tier_progress: 1000,
         }
+    }
+
+    pub fn with_stall_threshold(mut self, threshold: u64) -> Self {
+        self.max_contracts_without_tier_progress = threshold;
+        self
     }
 
     pub fn play_game(&self, seed: u64, strategy: &dyn Strategy) -> GameResult {
@@ -98,6 +115,9 @@ impl GameDriver {
         let milestone_set: HashSet<u32> = self.milestone_tiers.iter().cloned().collect();
         let mut reached_milestones: HashSet<u32> = HashSet::new();
 
+        let mut current_tier: u32 = 0;
+        let mut contracts_since_last_tier: u64 = 0;
+
         loop {
             let non_new_game: Vec<PossibleAction> = state
                 .possible_actions()
@@ -107,6 +127,7 @@ impl GameDriver {
 
             if non_new_game.is_empty() {
                 result.stuck = true;
+                result.exit_reason = ExitReason::Completed;
                 break;
             }
 
@@ -148,6 +169,13 @@ impl GameDriver {
                             result.max_tier_reached =
                                 Some(result.max_tier_reached.map_or(tier, |t: u32| t.max(tier)));
 
+                            if tier > current_tier {
+                                current_tier = tier;
+                                contracts_since_last_tier = 0;
+                            } else {
+                                contracts_since_last_tier += 1;
+                            }
+
                             if milestone_set.contains(&tier) && !reached_milestones.contains(&tier)
                             {
                                 reached_milestones.insert(tier);
@@ -161,6 +189,7 @@ impl GameDriver {
                             let tier = contract.tier.0;
                             result.contracts_failed += 1;
                             *result.failed_per_tier.entry(tier).or_insert(0) += 1;
+                            contracts_since_last_tier += 1;
                             let failure_type = match reason {
                                 ContractFailureReason::HarmfulTokenLimitExceeded { .. } => {
                                     "HarmfulTokenLimitExceeded"
@@ -182,10 +211,18 @@ impl GameDriver {
             }
 
             if reached_milestones.len() == self.milestone_tiers.len() {
+                result.exit_reason = ExitReason::Completed;
                 break;
             }
+
+            if contracts_since_last_tier >= self.max_contracts_without_tier_progress {
+                result.exit_reason = ExitReason::StallDetected;
+                break;
+            }
+
             if result.total_actions >= self.max_actions {
                 result.hit_action_limit = true;
+                result.exit_reason = ExitReason::ActionLimitExceeded;
                 break;
             }
         }

--- a/tests/simulation/main.rs
+++ b/tests/simulation/main.rs
@@ -28,6 +28,7 @@ fn smart_strategy_diagnostic() {
         base_seed: 42,
         max_actions_per_game: 100_000,
         milestone_tiers: vec![10, 15, 20, 25, 30, 35, 40, 45, 50],
+        max_contracts_without_tier_progress: 1000,
     };
 
     let runner = SimulationRunner::new(config);
@@ -79,6 +80,7 @@ fn smart_strategy_reaches_tier_50() {
         base_seed: 42,
         max_actions_per_game: 500_000,
         milestone_tiers: vec![10, 20, 30, 40, 50],
+        max_contracts_without_tier_progress: 1000,
     };
 
     let runner = SimulationRunner::new(config);

--- a/tests/simulation/runner.rs
+++ b/tests/simulation/runner.rs
@@ -13,6 +13,7 @@ pub struct SimulationConfig {
     pub base_seed: u64,
     pub max_actions_per_game: u64,
     pub milestone_tiers: Vec<u32>,
+    pub max_contracts_without_tier_progress: u64,
 }
 
 impl Default for SimulationConfig {
@@ -22,6 +23,7 @@ impl Default for SimulationConfig {
             base_seed: 42,
             max_actions_per_game: 200_000,
             milestone_tiers: vec![10, 20, 30, 40, 50],
+            max_contracts_without_tier_progress: 1000,
         }
     }
 }
@@ -54,6 +56,7 @@ pub struct StrategyReport {
     pub abandoned_per_tier: HashMap<u32, u64>,
     pub stuck_games: u32,
     pub action_limit_games: u32,
+    pub stalled_games: u32,
 }
 
 /// Runs multiple seeds for a strategy and aggregates results into a `StrategyReport`.
@@ -70,7 +73,8 @@ impl SimulationRunner {
         let driver = GameDriver::new(
             self.config.max_actions_per_game,
             self.config.milestone_tiers.clone(),
-        );
+        )
+        .with_stall_threshold(self.config.max_contracts_without_tier_progress);
 
         let mut all_results: Vec<GameResult> = Vec::new();
 
@@ -84,18 +88,19 @@ impl SimulationRunner {
                 self.config.games_per_strategy
             );
             let result = driver.play_game(seed, strategy);
+            let exit_label = match result.exit_reason {
+                crate::game_driver::ExitReason::Completed => "COMPLETED",
+                crate::game_driver::ExitReason::ActionLimitExceeded => "ACTION_LIMIT",
+                crate::game_driver::ExitReason::StallDetected => "STALLED",
+            };
             eprintln!(
-                "  max_tier={:?} completed={} failed={} abandoned={} actions={}{}",
+                "  max_tier={:?} completed={} failed={} abandoned={} actions={} [{}]",
                 result.max_tier_reached,
                 result.contracts_completed,
                 result.contracts_failed,
                 result.contracts_abandoned,
                 result.total_actions,
-                if result.hit_action_limit {
-                    " [LIMIT]"
-                } else {
-                    ""
-                },
+                exit_label,
             );
             all_results.push(result);
         }
@@ -173,6 +178,10 @@ impl SimulationRunner {
 
         let stuck_games = results.iter().filter(|r| r.stuck).count() as u32;
         let action_limit_games = results.iter().filter(|r| r.hit_action_limit).count() as u32;
+        let stalled_games = results
+            .iter()
+            .filter(|r| matches!(r.exit_reason, crate::game_driver::ExitReason::StallDetected))
+            .count() as u32;
 
         StrategyReport {
             strategy_name: name.to_string(),
@@ -188,6 +197,7 @@ impl SimulationRunner {
             abandoned_per_tier,
             stuck_games,
             action_limit_games,
+            stalled_games,
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces stall detection to the game simulation system to identify when a strategy is making no progress toward higher contract tiers. Games can now exit for three distinct reasons: successful completion, hitting the action limit, or detecting a stall condition.

## Key Changes
- **New `ExitReason` enum**: Added a serializable enum with three variants (`Completed`, `ActionLimitExceeded`, `StallDetected`) to explicitly track why a game ended
- **Stall detection logic**: Implemented tracking of contracts completed/failed since the last tier progression. Games exit with `StallDetected` when this counter exceeds a configurable threshold
- **Configurable stall threshold**: Added `max_contracts_without_tier_progress` field to `GameDriver` and `SimulationConfig` with a default of 1000 contracts, configurable via `with_stall_threshold()` builder method
- **Enhanced reporting**: Updated `StrategyReport` to include `stalled_games` count and improved game result logging to display the exit reason label (`COMPLETED`, `ACTION_LIMIT`, or `STALLED`)
- **Exit reason tracking**: All game termination paths now set the appropriate `exit_reason` on `GameResult`

## Implementation Details
- Stall detection tracks `current_tier` and `contracts_since_last_tier` during game execution
- The counter increments on both contract failures and completions at the same tier level
- The counter resets when a higher tier is reached
- Stall detection check runs after milestone completion check but before action limit check in the game loop
- All test configurations updated to include the new `max_contracts_without_tier_progress` field

https://claude.ai/code/session_01UWL635hSw5KGY9Q6xtworw