### PR TITLE
Add contents write permission to release builds workflow

### DIFF
--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
Added explicit `contents: write` permission to the release builds workflow job to enable write access to repository contents during the build process.

## Key Changes
- Added `permissions` block to the `build` job in the release-builds workflow
- Granted `contents: write` permission to allow the workflow to write to repository contents

## Implementation Details
This change follows GitHub Actions security best practices by explicitly declaring the minimum required permissions for the workflow job. The `contents: write` permission is necessary for operations that modify repository contents, such as creating releases, updating files, or pushing commits during the release build process.

https://claude.ai/code/session_018UBXXRwdrthPEcJWmt91wT